### PR TITLE
Use link markup instead of rdoc-ref for URLs in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,10 +74,10 @@ Type "rake --help" for all available options.
 
 === Rake Information
 
-* {Rake command-line}[rdoc-ref:doc/command_line_usage.rdoc]
-* {Writing Rakefiles}[rdoc-ref:doc/rakefile.rdoc]
-* The original {Rake announcement}[rdoc-ref:doc/rational.rdoc]
-* Rake {glossary}[rdoc-ref:doc/glossary.rdoc]
+* {Rake command-line}[link:doc/command_line_usage.rdoc]
+* {Writing Rakefiles}[link:doc/rakefile.rdoc]
+* The original {Rake announcement}[link:doc/rational.rdoc]
+* Rake {glossary}[link:doc/glossary.rdoc]
 
 === Presentations and Articles about Rake
 


### PR DESCRIPTION
You will know your audience better than me, but the links in the README that use `rdoc-ref` to markup the links do not work in Github. If you expect most people to view the README through an RDoc generator/viewer of some sort than the current optimization for RDoc is likely preferable. If the Github use-case is valid one, then consider this PR.

This PR switches those links to use `link` to markup the links instead.

According to the [RDoc link docs](http://docs.seattlerb.org/rdoc/RDoc/Markup.html#class-RDoc::Markup-label-Links):

> Use rdoc-ref: instead of link: to link to files generated by RDoc as the link target may be different across RDoc generators.

Again, you will probably know better than I would if there is likely to be variation in the target of those links across different RDoc generators. I'm skeptical, but I know relatively little about RDoc.

Since using `rdoc-ref` seems pretty reasonable, I've also opened [an issue with Github](https://github.com/github/markup/issues/420).
