### PR TITLE
Don't eat my ARGV!

### DIFF
--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -370,7 +370,7 @@ class TestRakeApplication < Rake::TestCase
     # HACK no assertions
   end
 
-  def test_handle_options_should_strip_options_from_argv
+  def test_handle_options_should_not_strip_options_from_argv
     assert !@app.options.trace
 
     valid_option = '--trace'
@@ -378,7 +378,7 @@ class TestRakeApplication < Rake::TestCase
 
     @app.handle_options
 
-    assert !ARGV.include?(valid_option)
+    assert ARGV.include?(valid_option)
     assert @app.options.trace
   end
 

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -457,8 +457,8 @@ class TestRakeApplicationOptions < Rake::TestCase
       throw :system_exit, :exit
     end
     @app.instance_eval do
-      handle_options
-      collect_command_line_tasks
+      args = handle_options
+      collect_command_line_tasks(args)
     end
     @tasks = @app.top_level_tasks
     @app.options


### PR DESCRIPTION
Change the way that OptionParser.parse! is called, so that it doesn't
directly sink its teeth into ARGV.  This necessitated changing the way that
collect_command_line_tasks get the list of command-line arguments to examine
to get tasks and environment variable definitions, but that's a relatively
minor thing.

This relates to jimweirich/rake#277.
