### PR TITLE
delete duplicated changelog line.

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -17,8 +17,6 @@ Enhancements:
 * Rake no longer edits ARGV.  This allows you to re-exec rake from a rake
   task.  Issue #277 by Matt Palmer.
 * Etc.nprocessors is used for counting the number of CPUs.
-* Rake no longer edits ARGV.  This allows you to re-exec rake from a rake
-  task.  Issue #277 by Matt Palmer.
 
 Bug fixes:
 


### PR DESCRIPTION
The bullet list's line 

> - Rake no longer edits ARGV.  This allows you to re-exec rake from a rake
>   task.  Issue #277 by Matt Palmer.

is duplicated.
