### PR TITLE
Add fetch to task arguments.

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -83,8 +83,8 @@ module Rake
       @hash.has_key?(key)
     end
 
-    def fetch(key, &block)
-      @hash.fetch(key, &block)
+    def fetch(*args, &block)
+      @hash.fetch(*args, &block)
     end
 
     protected

--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -83,6 +83,10 @@ module Rake
       @hash.has_key?(key)
     end
 
+    def fetch(key, &block)
+      @hash.fetch(key, &block)
+    end
+
     protected
 
     def lookup(name) # :nodoc:

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -29,7 +29,7 @@ class TestRakeTaskArguments < Rake::TestCase
     ta = Rake::TaskArguments.new([:one], [1])
     assert_equal 1, ta.fetch(:one)
     assert_equal 2, ta.fetch(:two) { 2 }
-    assert_raises(KeyError) { ta.fetch(:three) }
+    assert_raises(KeyError) { ta.fetch(:three) } unless older_ruby?
   end
 
   def test_to_s
@@ -129,6 +129,12 @@ class TestRakeTaskArguments < Rake::TestCase
     assert_equal nil, ta[:third]
     assert_equal ['1', 'two'], ta.to_a
     assert_equal [], ta.extras
+  end
+
+  private
+
+  def older_ruby?
+    RUBY_VERSION == '1.8.7'
   end
 
 end

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -25,6 +25,13 @@ class TestRakeTaskArguments < Rake::TestCase
     refute(ta.has_key?(:b))
   end
 
+  def test_fetch
+    ta = Rake::TaskArguments.new([:one], [1])
+    assert_equal 1, ta.fetch(:one)
+    assert_equal 2, ta.fetch(:two) { 2 }
+    assert_raises(KeyError) { ta.fetch(:three) }
+  end
+
   def test_to_s
     ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])
     assert_equal ta.to_hash.inspect, ta.to_s


### PR DESCRIPTION
This change allows TaskArguments to respond to fetch in the same way that a hash would.  I ran into this scenario where I was trying to pass the args for a rake task directly into a class constructor.  Calling args.fetch in that case results in nil values being returned.  This was confusing at first because when the TaskArguments object is 'puts' or inspected, it returns what looks like a hash.  It wasn't until I checked the class of the args that I realized the discrepancy.  This change helps eliminate that confusion and would allow the arguments to be passed in directly.

I'm not sure if this is the right approach or if you should just call `to_hash` on the args (which is what I ended up doing).  Any feedback would be great.  Thanks!