### PR TITLE
Offer alternatives if rake task not found

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -59,7 +59,20 @@ module Rake
       self.lookup(task_name, scopes) or
         enhance_with_matching_rule(task_name) or
         synthesize_file_task(task_name) or
-        fail "Don't know how to build task '#{task_name}'"
+        build_task_fail(task_name)
+    end
+
+    # If a task match wasn't found, try to offer suggestions.
+    # The task name must be at least 2 characters.
+    def build_task_fail(task_name)
+      msg = "Don't know how to build task '#{task_name}'"
+      if task_name.size > 1
+        matches = @tasks.keys.find_all{ |e| e =~ /#{task_name}/i }
+        if matches.size > 0
+          msg += ". Did you mean one of these?\n\n" + matches.map{ |e| "  #{e}" }.join("\n") + "\n"
+        end
+      end
+      fail msg
     end
 
     def synthesize_file_task(task_name) # :nodoc:

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -148,6 +148,15 @@ class TestRakeTask < Rake::TestCase
     assert_equal "Don't know how to build task 'leaves'", ex.message
   end
 
+  def test_find_with_alts
+    task :tfindx
+    assert_equal "tfindx", Task[:tfindx].name
+    ex = assert_raises(RuntimeError) { Task[:tfind] }
+    assert_match /Don\'t know how to build task \'tfind\'/, ex.message
+    assert_match /Did you mean one of these\?/, ex.message
+    assert_match /tfindx/, ex.message
+  end
+
   def test_defined
     assert ! Task.task_defined?(:a)
     task :a


### PR DESCRIPTION
If your rake task name happens to be wrong on the command line, the output is not that helpful. Next thing you know you're grepping through rake -T output.

This pull request does some simple matching to offer alternatives if the name you specified isn't found. For example, if you have tasks "foobar" and "foobaz", but accidentally type "rake foo" on the command line, you'll see this:

    Don't know how to build task 'foo'. Did you mean one of these?

      foobar
      foobaz