### PR TITLE
Remove an unneeded private declaration

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -291,9 +291,6 @@ module Rake
       result.flatten
     end
 
-
-    private
-
     # Return the current description, clearing it in the process.
     def get_description(task)
       desc = @last_description


### PR DESCRIPTION
TaskManager already has a private declaration in line 215.