### PR TITLE
Remove duplicates from FileList

### DIFF
--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -198,7 +198,8 @@ module Rake
 
     def <<(obj)
       resolve
-      @items << Rake.from_pathname(obj)
+      i = Rake.from_pathname(obj)
+      @items.push i unless @items.include? i
       self
     end
 
@@ -210,6 +211,7 @@ module Rake
         @pending_add = []
         resolve_exclude
       end
+      @items.uniq!
       self
     end
 
@@ -382,7 +384,7 @@ module Rake
     ]
 
     def import(array) # :nodoc:
-      @items = array
+      @items = array.uniq
       self
     end
 


### PR DESCRIPTION
I work with TeX and the pattern %w(*.log texput.*)
catches "texput.log" twice, which results in an error
when removing the file inside a :clean task.