### PR TITLE
Make FileList#exclude more analogous to FileList#include

### DIFF
--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -151,7 +151,11 @@ module Rake
     #
     def exclude(*patterns, &block)
       patterns.each do |pat|
-        @exclude_patterns << Rake.from_pathname(pat)
+        if pat.respond_to? :to_ary
+          exclude(*pat.to_ary)
+        else
+          @exclude_patterns << Rake.from_pathname(pat)
+        end
       end
       @exclude_procs << block if block_given?
       resolve_exclude unless @pending

--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -369,7 +369,10 @@ module Rake
         when Regexp
           fn =~ pat
         when GLOB_PATTERN
-          File.fnmatch?(pat, fn, File::FNM_PATHNAME | File::FNM_EXTGLOB)
+          flags = File::FNM_PATHNAME
+          # Ruby <= 1.9.3 does not support File::FNM_EXTGLOB
+          flags |= File::FNM_EXTGLOB if defined? File::FNM_EXTGLOB
+          File.fnmatch?(pat, fn, flags)
         else
           fn == pat
         end

--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -85,6 +85,8 @@ module Rake
       end
     end
 
+    GLOB_PATTERN = %r{[*?\[\{]}
+
     # Create a file list from the globbable patterns given.  If you wish to
     # perform multiple includes or excludes at object build time, use the
     # "yield self" pattern.
@@ -215,7 +217,7 @@ module Rake
 
     def resolve_add(fn) # :nodoc:
       case fn
-      when %r{[*?\[\{]}
+      when GLOB_PATTERN
         add_matching(fn)
       else
         self << fn
@@ -362,8 +364,8 @@ module Rake
         case pat
         when Regexp
           fn =~ pat
-        when /[*?]/
-          File.fnmatch?(pat, fn, File::FNM_PATHNAME)
+        when GLOB_PATTERN
+          File.fnmatch?(pat, fn, File::FNM_PATHNAME | File::FNM_EXTGLOB)
         else
           fn == pat
         end

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -211,6 +211,7 @@ class TestRakeFileList < Rake::TestCase
   end
 
   def test_exclude_curly_bracket_pattern
+    skip 'brace pattern matches not supported' unless defined? File::FNM_EXTGLOB
     fl = FileList['*'].exclude('{abc,xyz}.c')
     assert_equal %w[abc.h abc.x cfiles existing x.c xyzzy.txt], fl
   end

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -210,6 +210,11 @@ class TestRakeFileList < Rake::TestCase
     assert_equal FileList, fl.class
   end
 
+  def test_exclude_curly_bracket_pattern
+    fl = FileList['*'].exclude('{abc,xyz}.c')
+    assert_equal %w[abc.h abc.x cfiles existing x.c xyzzy.txt], fl
+  end
+
   def test_default_exclude
     fl = FileList.new
     fl.clear_exclude

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -215,6 +215,17 @@ class TestRakeFileList < Rake::TestCase
     assert_equal %w[abc.h abc.x cfiles existing x.c xyzzy.txt], fl
   end
 
+  def test_exclude_an_array
+    fl = FileList['*'].exclude(['existing', '*.c'])
+    assert_equal %w[abc.h abc.x cfiles xyzzy.txt], fl
+  end
+
+  def test_exclude_a_filelist
+    excluded = FileList['existing', '*.c']
+    fl = FileList['*'].exclude(excluded)
+    assert_equal %w[abc.h abc.x cfiles xyzzy.txt], fl
+  end
+
   def test_default_exclude
     fl = FileList.new
     fl.clear_exclude


### PR DESCRIPTION
This PR changes FileList so that `a_filelist.exclude(something)` is more consistent with `a_filelist.exclude(*FileList[something])`.

Now `FileList#exclude` can accept curly brace patterns, like `"{foo,bar}.rb"`, the same way `FileList#include` does.

And it now also accepts arrays, or array-like things, excluding each element of that array.