### PR TITLE
Chained extensions

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -131,7 +131,7 @@ module Rake
         "Rule Recursion Too Deep" if level >= 16
       @rules.each do |pattern, args, extensions, block|
         if pattern.match(task_name)
-          task = attempt_rule(task_name, args, extensions, block, level)
+          task = attempt_rule(task_name, pattern, args, extensions, block, level)
           return task if task
         end
       end
@@ -245,8 +245,8 @@ module Rake
     end
 
     # Attempt to create a rule given the list of prerequisites.
-    def attempt_rule(task_name, args, extensions, block, level)
-      sources = make_sources(task_name, extensions)
+    def attempt_rule(task_name, task_pattern, args, extensions, block, level)
+      sources = make_sources(task_name, task_pattern, extensions)
       prereqs = sources.map { |source|
         trace_rule level, "Attempting Rule #{task_name} => #{source}"
         if File.exist?(source) || Rake::Task.task_defined?(source)
@@ -267,7 +267,7 @@ module Rake
 
     # Make a list of sources from the list of file name extensions /
     # translation procs.
-    def make_sources(task_name, extensions)
+    def make_sources(task_name, task_pattern, extensions)
       result = extensions.map { |ext|
         case ext
         when /%/
@@ -275,7 +275,8 @@ module Rake
         when %r{/}
           ext
         when /^\./
-          task_name.ext(ext)
+          source = task_name.sub(task_pattern, ext)
+          source == ext ? task_name.ext(ext) : source
         when String
           ext
         when Proc, Method

--- a/test/test_rake_rules.rb
+++ b/test/test_rake_rules.rb
@@ -10,6 +10,7 @@ class TestRakeRules < Rake::TestCase
   OBJFILE    = "abc.o"
   FOOFILE    = "foo"
   DOTFOOFILE = ".foo"
+  MINFILE = 'abc.min.o'
 
   def setup
     super
@@ -383,6 +384,17 @@ class TestRakeRules < Rake::TestCase
     end
     Task[OBJFILE].invoke
     assert_equal ["#{OBJFILE} - abc.c"], @runs
+  end
+
+  def test_works_with_chained_extensions_in_rules
+    create_file(OBJFILE)
+    rule('.min.o' => ['.o']) do |t|
+      @runs << t.name
+      assert_equal OBJFILE, t.source
+      assert_equal MINFILE, t.name
+    end
+    Task[MINFILE].invoke
+    assert_equal [MINFILE], @runs
   end
 
 end

--- a/test/test_rake_rules.rb
+++ b/test/test_rake_rules.rb
@@ -10,7 +10,7 @@ class TestRakeRules < Rake::TestCase
   OBJFILE    = "abc.o"
   FOOFILE    = "foo"
   DOTFOOFILE = ".foo"
-  MINFILE = 'abc.min.o'
+  MINFILE    = 'abc.min.o'
 
   def setup
     super


### PR DESCRIPTION
rules such as 

``` ruby
rule ".min.js" => ".js" do |t|
end
```

didn't work because Rake would simple replace the js part of".min.js" with ".js", creating a cyclic dependency. This PR makes rules like this work by always making sure the whole target pattern of is replaced, rather than just the very final extension. 

All tests green. A test for the new feature added.
