### PR TITLE
Add a flexible gemspec

### DIFF
--- a/.gemspec_utils.rb
+++ b/.gemspec_utils.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
+require 'yaml'
+require 'erb'
+
+module GemspecBoilerplate
+  module_function
+  def camelize(string, uppercase_first_letter = true)
+    string = string.to_s
+    if uppercase_first_letter
+      string = string.sub(/^[a-z\d]*/) { $&.capitalize }
+    else
+      string = string.sub(/^(?:(?=\b|[A-Z_])|\w)/) { $&.downcase }
+    end
+    string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{$2.capitalize}" }
+    string.gsub!(/\//, '::')
+    string
+  end
+
+  def add_naming_metadata!(spec)
+    metadata = spec.metadata
+    metadata.merge!({
+      "name" => spec.name,
+      "underscored_name" => spec.name.tr('-', '_'),
+      "namespaced_path"  => spec.name.tr('-', '/')
+
+    })
+    metadata["constant_name"] = camelize(metadata["namespaced_path"])
+  end
+
+  def templates
+    return @templates if @templates
+    File.open(__FILE__) do |this_file|
+      this_file.find { |line| line =~ /^__END__ *$/ }
+      @templates = YAML.load(this_file.read)
+    end
+    @templates
+  end
+
+  def template_write(filename, config, template_str)
+    File.write(filename, ERB.new(template_str, nil,'-').result(binding))
+  end
+
+  def bootstrap_lib!(spec)
+    m = spec.metadata
+    namespaced_path = m["namespaced_path"]
+    versionfile = "lib/#{namespaced_path}/version.rb"
+    rbfile = "lib/#{namespaced_path}.rb"
+    FileUtils.mkdir_p File.dirname(versionfile)
+    config = m.dup
+    config["constant_array"] = m["constant_name"].split("::")
+
+    template_write(rbfile, config, templates["newgem.tt"])  unless File.exist?(rbfile)
+    template_write(versionfile, config, templates["version.rb.tt"])  unless File.exist?(versionfile)
+  end
+end
+
+__END__
+---
+newgem.tt: |
+  require "<%=config["namespaced_path"]%>/version"
+  <%- if config[:ext] -%>
+  require "<%=config["namespaced_path"]%>/<%=config[:underscored_name]%>"
+  <%- end -%>
+
+  <%- config["constant_array"].each_with_index do |c,i| -%>
+  <%= '  '*i %>module <%= c %>
+  <%- end -%>
+  <%= '  '*config["constant_array"].size %>
+  <%- (config["constant_array"].size-1).downto(0) do |i| -%>
+  <%= '  '*i %>end
+  <%- end -%>
+version.rb.tt: |
+  <%- config["constant_array"].each_with_index do |c,i| -%>
+  <%= '  '*i %>module <%= c %>
+  <%- end -%>
+  <%= '  '*config["constant_array"].size %>VERSION = "0.1.0"
+  <%- (config["constant_array"].size-1).downto(0) do |i| -%>
+  <%= '  '*i %>end
+  <%- end -%>

--- a/gemspec.gemspec
+++ b/gemspec.gemspec
@@ -1,0 +1,22 @@
+# coding: utf-8
+
+require_relative 'gemspec_boilerplate'
+
+spec = Gem::Specification.new do |s|
+
+  GemspecBoilerplate.boilerplate(s)
+
+  #s.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
+
+  #####Must change
+  s.summary       = %q{Rake is a Make-like program implemented in ruby}
+  s.description   = s.summary
+  s.licenses      = %w[MIT]
+
+
+  #####Unlikely to change
+  s.email         = []
+  s.homepage      = "https://github.com/ruby/#{s.name}.git"
+  ###################################
+
+end

--- a/gemspec_boilerplate.rb
+++ b/gemspec_boilerplate.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
+require 'fileutils'
+require 'erb'
+require_relative '.gemspec_utils'
+
+$__DIR__ = File.expand_path(File.dirname(__FILE__))
+lib = File.expand_path('lib', $__DIR__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+module GemspecBoilerplate
+  module_function
+  def boilerplate(s)
+    #####Won't change as long as you follow conventions
+    s.name           = File.basename($__DIR__)
+    add_naming_metadata!(s)
+    bootstrap_lib!(s)
+    metadata = s.metadata
+
+    require "#{metadata["namespaced_path"]}/version"
+    spec_module         = Object.const_get(metadata["constant_name"])
+    s.version        = spec_module::VERSION
+    s.files         = `git ls-files -z`.split("\x0")
+    s.test_files    = s.files.grep(%r{^(test|s|features)/})
+    s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|s|features)/}) }
+    s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+    s.require_paths = ["lib"]
+    s.authors       = `git shortlog -sn`.split("\n").map {|a| a.sub(/^[\d\s]*/, '') }
+  end
+end
+

--- a/lib/rake.rb
+++ b/lib/rake.rb
@@ -20,9 +20,6 @@
 # IN THE SOFTWARE.
 #++
 
-module Rake
-  VERSION = '10.4.2'
-end
 
 require 'rake/version'
 

--- a/lib/rake/version.rb
+++ b/lib/rake/version.rb
@@ -1,4 +1,7 @@
 module Rake
+
+  VERSION = '10.4.2'
+
   module Version # :nodoc: all
     MAJOR, MINOR, BUILD, *OTHER = Rake::VERSION.split '.'
 


### PR DESCRIPTION
This triplet of files should work for any gem project.

gemspec.gemspec
  is for human-input gemspec information specific to a gem project (such
  as description, summary, or contact emails)
  it requires 'gemspec_boilerplate.rb'

gemspec_boilerplate.rb
  is for gemspec information that mostly doesn't change or is retrieved
  automatically from other sources (i.e. files list and authors list are
  retrieved from git, project name and relevant constants are inferred
  from the project's directory name)

.gemspec_utils.rb
  Utils used by 'gemspec_boilerplate.rb' such as `camelize` or templates
  for bootstrapping the lib directory if it doesn't already exist (that
  ensures that lib/<project_name>/version.rb, which is used by
  gemspec_boilerplate.rb, exists)

Doing `gem build gemspec.gemspec` in a directory named (=<project-name>) rake will build `rake-<version>.gem` where <version> is gotten from lib/<project-name>/version.rb from `Rake::VERSION`. 