### PR TITLE
Remove unnecessary monkey patching

### DIFF
--- a/lib/rake/ext/time.rb
+++ b/lib/rake/ext/time.rb
@@ -4,13 +4,15 @@
 require 'rake/early_time'
 require 'rake/late_time'
 
-class Time # :nodoc: all
-  alias rake_original_time_compare :<=>
-  def <=>(other)
-    if Rake::EarlyTime === other || Rake::LateTime === other
-      - other.<=>(self)
-    else
-      rake_original_time_compare(other)
+if RUBY_VERSION < "1.9"
+  class Time # :nodoc: all
+    alias rake_original_time_compare :<=>
+    def <=>(other)
+      if Rake::EarlyTime === other || Rake::LateTime === other
+        - other.<=>(self)
+      else
+        rake_original_time_compare(other)
+      end
     end
   end
 end


### PR DESCRIPTION
This kind of monkey patching isn't really necessary since `Time#<=>` is smart enough to try inverting the operands if the argument it receives is not an instance of Time.

Also the alias chain can be a source of headaches if you want to use it simultaneously with the new method `Module#prepend`: https://github.com/rails/rails/pull/19878/#issuecomment-106851263