### PR TITLE
custom test loader: t.load = "file://path/to/loader"

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -57,9 +57,10 @@ module Rake
 
     # Style of test loader to use.  Options are:
     #
-    # * :rake -- Rake provided test loading script (default).
+    # * :rake   -- Rake provided test loading script (default).
     # * :testrb -- Ruby provided test loading script.
     # * :direct -- Load tests using command line loader.
+    # * 'file://custom/loader.rb' -- Load tests using custom loader
     #
     attr_accessor :loader
 
@@ -171,6 +172,10 @@ module Rake
         "-S testrb #{fix}"
       when :rake
         "#{rake_include_arg} \"#{rake_loader}\""
+      when %r[\Afile://(.+)\Z]
+        find_custom_loader($1)
+      else
+        fail 'unexpected loader'
       end
     end
 
@@ -207,6 +212,10 @@ module Rake
         return path if File.exist? file_path
       end
       nil
+    end
+
+    def find_custom_loader(fn) # :nodoc:
+      find_file(fn) || fail('custom loader not found in $LOAD_PATH')
     end
 
   end

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -135,6 +135,36 @@ class TestRakeTestTask < Rake::TestCase
     assert_match(/^-S testrb +$/, test_task.run_code)
   end
 
+  def test_run_code_custom_loader
+    custom_loader = 'rake'
+
+    test_task = Rake::TestTask.new do |t|
+      t.loader = "file://#{custom_loader}"
+    end
+
+    regexp_quoted_custom_loader = Regexp.quote(custom_loader)
+
+    assert_match(/#{regexp_quoted_custom_loader}[.]rb$/, test_task.run_code)
+  end
+
+  def test_run_code_custom_loader_not_found
+    custom_loader = 'not_found'
+
+    test_task = Rake::TestTask.new do |t|
+      t.loader = "file://#{custom_loader}"
+    end
+
+    assert_raises(RuntimeError) { test_task.run_code }
+  end
+
+  def test_run_code_unexpected_loader
+    test_task = Rake::TestTask.new do |t|
+      t.loader = :unexpected
+    end
+
+    assert_raises(RuntimeError) { test_task.run_code }
+  end
+
   def test_test_files_equals
     tt = Rake::TestTask.new do |t|
       t.test_files = FileList['a.rb', 'b.rb']


### PR DESCRIPTION
This code allows users of Rake::TestTask to use custom test loaders.

This was a required for an experiment we've been doing at Subledger that required the test files to be loaded rather than required due to non-'.rb' filename extensions.

When implementing this, I noticed that there was no else-clause in the case statement in #load so I added one.

Wrote some tests for the custom loader option (pass a file:// URI string to loader) and the else-clause too.

Anxious to hear your feedback.
