### PR TITLE
Use --no-document option instead of --no-rdoc and --no-ri option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 after_script:
 - ruby -Ilib bin/rake travis:after -t
 before_script:
-- gem install hoe-travis --no-rdoc --no-ri
-- gem install minitest -v '~> 5.0' --no-rdoc --no-ri
+- gem install hoe-travis --no-document
+- gem install minitest -v '~> 5.0' --no-document
 - ruby -Ilib bin/rake travis:before -t
 language: ruby
 sudo: false


### PR DESCRIPTION
--no-rdoc and --no-ri option is deprecated.
Please see [gem install(command reference)](http://guides.rubygems.org/command-reference/#gem-install).
