### PR TITLE
Add a :triggers option when defining rake tasks to run tasks after the task is run

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -209,7 +209,7 @@ module Rake
     end
     private :add_chain_to
 
-    # Invoke all the prerequisites of a task.
+    # Invoke a set of subtasks.
     def invoke_subtasks(subtasks, task_args, invocation_chain) # :nodoc:
       if application.options.always_multitask
         invoke_subtasks_concurrently(subtasks, task_args, invocation_chain)
@@ -221,7 +221,7 @@ module Rake
       end
     end
 
-    # Invoke all the prerequisites of a task in parallel.
+    # Invoke a set of subtasks in parallel.
     def invoke_subtasks_concurrently(subtasks, task_args, invocation_chain)# :nodoc:
       futures = subtasks.map do |p|
         subtask_args = task_args.new_scope(p.arg_names)

--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -67,8 +67,8 @@ module Rake
       define_task(Rake::FileTask, task_name)
     end
 
-    # Resolve the arguments for a task/rule.  Returns a triplet of
-    # [task_name, arg_name_list, prerequisites].
+    # Resolve the arguments for a task/rule.  Returns a quadruple of
+    # [task_name, arg_name_list, prerequisites, triggers].
     def resolve_args(args)
       if args.last.is_a?(Hash)
         if args.last.include?(:triggers)

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -105,9 +105,10 @@ class TestRakeTask < Rake::TestCase
 
   def test_clear
     desc "a task"
-    t = task("t" => "a") { }
+    t = task("t" => "a", :triggers => :tr) { }
     t.clear
     assert t.prerequisites.empty?, "prerequisites should be empty"
+    assert t.triggers.empty?, "triggers should be empty"
     assert t.actions.empty?, "actions should be empty"
     assert_nil t.comment, "comments should be empty"
   end
@@ -117,6 +118,13 @@ class TestRakeTask < Rake::TestCase
     assert_equal ['a', 'b'], t.prerequisites
     t.clear_prerequisites
     assert_equal [], t.prerequisites
+  end
+
+  def test_clear_triggers
+    t = task("t" => ["a", "b"], :triggers => :tr)
+    assert_equal [:tr], t.triggers
+    t.clear_triggers
+    assert_equal [], t.triggers
   end
 
   def test_clear_actions

--- a/test/test_rake_task_manager_argument_resolution.rb
+++ b/test/test_rake_task_manager_argument_resolution.rb
@@ -3,13 +3,29 @@ require File.expand_path('../helper', __FILE__)
 class TestRakeTaskManagerArgumentResolution < Rake::TestCase
 
   def test_good_arg_patterns
-    assert_equal [:t, [], []],       task(:t)
-    assert_equal [:t, [], [:x]],     task(:t => :x)
-    assert_equal [:t, [], [:x, :y]], task(:t => [:x, :y])
+    assert_equal [:t, [], [], []],       task(:t)
+    assert_equal [:t, [], [:x], []],     task(:t => :x)
+    assert_equal [:t, [], [:x, :y], []], task(:t => [:x, :y])
 
-    assert_equal [:t, [:a, :b], []],       task(:t, [:a, :b])
-    assert_equal [:t, [:a, :b], [:x]],     task(:t, [:a, :b] => :x)
-    assert_equal [:t, [:a, :b], [:x, :y]], task(:t, [:a, :b] => [:x, :y])
+    assert_equal [:t, [:a, :b], [], []],       task(:t, [:a, :b])
+    assert_equal [:t, [:a, :b], [:x], []],     task(:t, [:a, :b] => :x)
+    assert_equal [:t, [:a, :b], [:x, :y], []], task(:t, [:a, :b] => [:x, :y])
+
+    assert_equal [:t, [], [], [:tr]],       task(:t, :triggers => :tr)
+    assert_equal [:t, [], [:x], [:tr]],     task(:t => :x, :triggers => :tr)
+    assert_equal [:t, [], [:x, :y], [:tr]], task(:t => [:x, :y], :triggers => :tr)
+
+    assert_equal [:t, [:a, :b], [], [:tr]],       task(:t, [:a, :b], :triggers => :tr)
+    assert_equal [:t, [:a, :b], [:x], [:tr]],     task(:t, [:a, :b] => :x, :triggers => :tr)
+    assert_equal [:t, [:a, :b], [:x, :y], [:tr]], task(:t, [:a, :b] => [:x, :y], :triggers => :tr)
+
+    assert_equal [:t, [], [], [:tr1, :tr2]],       task(:t, :triggers => [:tr1, :tr2])
+    assert_equal [:t, [], [:x], [:tr1, :tr2]],     task(:t => :x, :triggers => [:tr1, :tr2])
+    assert_equal [:t, [], [:x, :y], [:tr1, :tr2]], task(:t => [:x, :y], :triggers => [:tr1, :tr2])
+
+    assert_equal [:t, [:a, :b], [], [:tr1, :tr2]],       task(:t, [:a, :b], :triggers => [:tr1, :tr2])
+    assert_equal [:t, [:a, :b], [:x], [:tr1, :tr2]],     task(:t, [:a, :b] => :x, :triggers => [:tr1, :tr2])
+    assert_equal [:t, [:a, :b], [:x, :y], [:tr1, :tr2]], task(:t, [:a, :b] => [:x, :y], :triggers => [:tr1, :tr2])
   end
 
   def task(*args)


### PR DESCRIPTION
Sometimes I want a task to trigger other tasks AFTER it's been run, rather than before, like a prerequisite.

This functionality is completely backwards compatible.

For example:

```
task default: [:p1, :p2], triggers: [:t1, :t2] do
  puts 'default'
end

[:p1, :p2, :t1, :t2].each do |t|
  task t do
    puts t
  end
end
```
would output
```
p1
p2
default
t1
t2
```