### PR TITLE
Improve markup by modifying a linux command of 'CD' into lowercase 'cd' (enclosed by '+')

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -9,7 +9,7 @@ http://github.com/ruby/rake . The public git clone URL is
 
 If you wish to run the unit and functional tests that come with Rake:
 
-* CD into the top project directory of rake.
+* +cd+ into the top project directory of rake.
 * Type one of the following:
 
     rake newb    # If you have never run rake's tests


### PR DESCRIPTION
I changed CD to `cd` (enclosed by `+`) in CONTRIBUTING.rdoc.

I guess CD in CONTRIBUTING.rdoc is supposed to mean a linux `cd` command, but if it is written in uppercase, it might be confusing because it is normally written in lowercase(http://www.linfo.org/cd.html).

It is a subtle change but to make it a little bit easier to understand. 