### PR TITLE
Make FileList#pathmap behave like String#pathmap

### DIFF
--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -264,8 +264,8 @@ module Rake
     # Apply the pathmap spec to each of the included file names, returning a
     # new file list with the modified paths.  (See String#pathmap for
     # details.)
-    def pathmap(spec=nil)
-      collect { |fn| fn.pathmap(spec) }
+    def pathmap(spec=nil, &block)
+      collect { |fn| fn.pathmap(spec, &block) }
     end
 
     # Return a new FileList with <tt>String#ext</tt> method applied to

--- a/test/test_rake_file_list_path_map.rb
+++ b/test/test_rake_file_list_path_map.rb
@@ -4,5 +4,12 @@ class TestRakeFileListPathMap < Rake::TestCase
   def test_file_list_supports_pathmap
     assert_equal ['a', 'b'], FileList['dir/a.rb', 'dir/b.rb'].pathmap("%n")
   end
+
+  def test_file_list_supports_pathmap_with_a_block
+    mapped = FileList['dir/a.rb', 'dir/b.rb'].pathmap("%{.*,*}n") do |name|
+      name.upcase
+    end
+    assert_equal ['A', 'B'], mapped
+  end
 end
 


### PR DESCRIPTION
`String#pathmap` accepts a block to perform replacements but `FileList#pathmap` ignores the block given.

This is to make FileList accept and pass the block to the String method.