### PR TITLE
Historical info on Jim, acknowledgement and thanks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -144,10 +144,12 @@ merchantability and fitness for a particular purpose.
 
 Rake was originally created by Jim Weirich, who unfortunately passed away in
 February 2014. This repository was originally hosted at
-[github.com/jimweirich/rake](https://github.com/jimweirich/rake/), however
-with his passing, has been moved to [ruby/rake](https://github.com/ruby/rake).
+{github.com/jimweirich/rake}[https://github.com/jimweirich/rake/], however
+with his passing, has been moved to {ruby/rake}[https://github.com/ruby/rake].
 
 You can view Jim's last commit here:
 https://github.com/jimweirich/rake/tree/336559f28f55bce418e2ebcc0a57548dcbac4025
+
+You can {read more about Jim}[https://en.wikipedia.org/wiki/Jim_Weirich] at Wikipedia.
 
 Thank you for this great tool, Jim. We'll remember you.

--- a/README.rdoc
+++ b/README.rdoc
@@ -108,6 +108,8 @@ other projects with similar (and not so similar) goals.
 
 == Credits
 
+[<b>Jim Weirich</b>] Who originally created Rake.
+
 [<b>Ryan Dlugosz</b>] For the initial conversation that sparked Rake.
 
 [<b>nobu.nokada@softhome.net</b>] For the initial patch for rule support.
@@ -138,3 +140,14 @@ This software is provided "as is" and without any express or implied
 warranties, including, without limitation, the implied warranties of
 merchantability and fitness for a particular purpose.
 
+== Historical
+
+Rake was originally created by Jim Weirich, who unfortunately passed away in
+February 2014. This repository was originally hosted at
+[github.com/jimweirich/rake](https://github.com/jimweirich/rake/), however
+with his passing, has been moved to [ruby/rake](https://github.com/ruby/rake).
+
+You can view Jim's last commit here:
+https://github.com/jimweirich/rake/tree/336559f28f55bce418e2ebcc0a57548dcbac4025
+
+Thank you for this great tool, Jim. We'll remember you.


### PR DESCRIPTION
This is just a friendly (albeit somber) pull request to acknowledge Jim Weirich in a more salient, respectful way. The original copyright statement under "other stuff", regardless of who put it there, now seems almost disrespectful, as if he's an afterthought and nothing more.

It's important that we acknowledge and thank innovators for their work, even in death; such ongoing acknowledgement shows veterans and newcomers alike that building great things leaves a lasting legacy; seeing that legacy can inspire others to build *their own* legacy by contributing to the community.

More functionally, newcomers to Ruby might see lots of references to Jim and jimweirich/rake as the repository location (e.g. books, old articles/blog posts, etc.), so this may clear up some confusion.

Merely a friendly suggestion; please discuss or ask questions if you have them. Thanks!