### PR TITLE
Fix TestTask verbose

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -128,6 +128,7 @@ module Rake
       opts = @ruby_opts.dup
       opts.unshift("-I\"#{lib_path}\"") unless @libs.empty?
       opts.unshift("-w") if @warning
+      opts.unshift('--verbose') if @verbose
       opts.join(" ")
     end
 

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -10,6 +10,7 @@ class TestRakeTestTask < Rake::TestCase
     assert_equal :test, tt.name
     assert_equal ['lib'], tt.libs
     assert_equal 'test/test*.rb', tt.pattern
+    assert_equal false, tt.warning
     assert_equal false, tt.verbose
     assert Task.task_defined?(:test)
   end
@@ -19,6 +20,7 @@ class TestRakeTestTask < Rake::TestCase
       t.description = "Run example tests"
       t.libs = ['src', 'ext']
       t.pattern = 'test/tc_*.rb'
+      t.warning = true
       t.verbose = true
     end
     refute_nil tt
@@ -26,7 +28,10 @@ class TestRakeTestTask < Rake::TestCase
     assert_equal :example, tt.name
     assert_equal ['src', 'ext'], tt.libs
     assert_equal 'test/tc_*.rb', tt.pattern
+    assert_equal true, tt.warning
     assert_equal true, tt.verbose
+    assert_match(/-w/, tt.ruby_opts_string)
+    assert_match(/--verbose/, tt.ruby_opts_string)
     assert Task.task_defined?(:example)
   end
 
@@ -142,5 +147,4 @@ class TestRakeTestTask < Rake::TestCase
 
     assert_equal ["a.rb", 'b.rb'], tt.file_list.to_a
   end
-
 end


### PR DESCRIPTION
`rake test —verbose` did not result in verbose mode for MiniTest.

The verbose option needs to be forwarded to the Ruby call.

Missing tests are added.