### PR TITLE
Fix special_return method's result wrapping to be more dynamic

### DIFF
--- a/doc/rake.1
+++ b/doc/rake.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH RAKE 1 "August 27, 2014" "rake 10.3.2" "Rake User Commands"
+.TH RAKE 1 "December 3, 2014" "rake 10.4.2" "Rake User Commands"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -16,7 +16,7 @@
 .\" .sp <n>    insert n+1 empty lines
 .\" for manpage-specific macros, see man(7)
 .SH NAME
-rake \- a make-like build utility for Ruby 
+rake \- a make-like build utility for Ruby
 .SH SYNOPSIS
 \fBrake\fR [\fI\-f rakefile\fR] {\fIOPTIONS\fR} \fITARGETS...\fR
 .br
@@ -136,6 +136,6 @@ Display a help message.
 The complete documentation for \fBrake\fR has been installed at \fI/usr/share/doc/rake-doc/html/index.html\fR. It is also available online at \fIhttp://docs.seattlerb.org/rake\fR.
 .SH AUTHOR
 .B rake
-was written by Jim Weirich <jim@weirichhouse.org> 
+was written by Jim Weirich <jim@weirichhouse.org>
 .PP
 This manual was created by Caitlin Matos <caitlin.matos@zoho.com> for the Debian project (but may be used by others). It was inspired by the manual by Jani Monoses <jani@iv.ro> for the Ubuntu project.

--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -70,7 +70,7 @@ module Rake
           def #{sym}(*args, &block)
             resolve
             result = @items.send(:#{sym}, *args, &block)
-            FileList.new.import(result)
+            self.class.new.import(result)
           end
         }, __FILE__, ln
       else

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -642,6 +642,21 @@ class TestRakeFileList < Rake::TestCase
     assert_equal FileList, r.class
   end
 
+  def test_special_return_delegating_methods_object_type
+    custom_file_list = Class.new(FileList)
+    f = custom_file_list.new
+
+    FileList::SPECIAL_RETURN.each do |m|
+      r = if [].method(m).arity == 1
+            f.send(m, [])
+          else
+            f.send(m)
+          end
+
+      assert_equal custom_file_list, r.class
+    end
+  end
+
   def test_file_utils_can_use_filelists
     cfiles = FileList['*.c']
 


### PR DESCRIPTION
Hi,

there is a little issue with the FileList SPECIAL_RETURNs:
```
class CustomFileList < Rake::FileList
end

c = CustomFileList.new #=> []
c.class #=> CustomFileList

c.uniq.class #=> Rake::FileList but should be a CustomFileList
```
What do you think about this fix?
