### PR TITLE
More helpful error message for unknown tasks.

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -59,7 +59,7 @@ module Rake
       self.lookup(task_name, scopes) or
         enhance_with_matching_rule(task_name) or
         synthesize_file_task(task_name) or
-        fail "Don't know how to build task '#{task_name}'"
+        fail "Don't know how to build task '#{task_name}' (see --tasks)"
     end
 
     def synthesize_file_task(task_name) # :nodoc:

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -145,7 +145,7 @@ class TestRakeTask < Rake::TestCase
     task :tfind
     assert_equal "tfind", Task[:tfind].name
     ex = assert_raises(RuntimeError) { Task[:leaves] }
-    assert_equal "Don't know how to build task 'leaves'", ex.message
+    assert_equal "Don't know how to build task 'leaves' (see --tasks)", ex.message
   end
 
   def test_defined

--- a/test/test_rake_task_manager.rb
+++ b/test/test_rake_task_manager.rb
@@ -24,7 +24,7 @@ class TestRakeTaskManager < Rake::TestCase
       @tm['bad']
     end
 
-    assert_equal "Don't know how to build task 'bad'", e.message
+    assert_equal "Don't know how to build task 'bad' (see --tasks)", e.message
   end
 
   def test_name_lookup


### PR DESCRIPTION
Addresses issue #22. Makes it a bit easier for new users to get started by pointing them at the `--task` parameter if they e.g. run rake with no arguments in a project with no default task.