### PR TITLE
Fix contributing documentation: install "hoe" gem dependency

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -10,6 +10,10 @@ http://github.com/ruby/rake . The public git clone URL is
 If you wish to run the unit and functional tests that come with Rake:
 
 * +cd+ into the top project directory of rake.
+* Install the +hoe+ gem dependency:
+
+    gem install hoe # Unless the hoe gem is already installed
+
 * Type one of the following:
 
     rake newb    # If you have never run rake's tests

--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -16,8 +16,8 @@ If you wish to run the unit and functional tests that come with Rake:
 
 * Type one of the following:
 
-    rake newb    # If you have never run rake's tests
-    rake         # If you have run rake's tests
+    rake newb       # If you have never run rake's tests
+    rake            # If you have run rake's tests
 
 = Issues and Bug Reports
 


### PR DESCRIPTION
@hsbt _et al._ - I'm submitting a minor "documentation fix" for the `CONTRIBUTING.rdoc` file, which didn't include instructions for installing the `"hoe"` gem dependency.

It's a bit off-putting for newbies to follow the instructions, only to get the following error message when running `rake newb` in a Ruby environment in which the `"hoe"` gem hasn't been previously installed:

```shell
$ rake newb
rake aborted!
LoadError: cannot load such file -- hoe
/Users/pvdb/Workarea/pvdb/rake/Rakefile:18:in `<top (required)>'
(See full trace by running task with --trace)
$_
```