### PR TITLE
Pluralize (for consistency)

### DIFF
--- a/lib/rake/clean.rb
+++ b/lib/rake/clean.rb
@@ -70,7 +70,7 @@ end
 
 CLOBBER = ::Rake::FileList.new
 
-desc "Remove any generated file."
+desc "Remove any generated files."
 task :clobber => [:clean] do
   Rake::Cleaner.cleanup_files(CLOBBER)
 end


### PR DESCRIPTION
@hsbt _et al._ - another minor "documentation fix" in this PR, one that makes the description of the `"clobber"` task consistent with the description of the `"clean"` task, as they use singular/plural nouns inconsistently at the moment.

**before:**

```shell
$ rake -T | egrep '^rake (clean|clobber)'
rake clean    # Remove any temporary products
rake clobber  # Remove any generated file
$ _
```

**after:**

```shell
$ rake -T | egrep '^rake (clean|clobber)'
rake clean    # Remove any temporary products
rake clobber  # Remove any generated files
$ _
```


Some diehards might argue that "any" should only be used in conjunction with uncountable nouns, and then only in questions or negative sentences, making these task descriptions grammatically incorrect, but at least with this PR they are consistently incorrect.  :smile: