### PR TITLE
Mark the FIXNUM_MAX constant as private with an annotation

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -783,7 +783,8 @@ module Rake
       backtrace.find { |str| str =~ re } || ''
     end
 
-  private
+    # private -----------------------------------------------------------------
+
     FIXNUM_MAX = (2**(0.size * 8 - 2) - 1) # :nodoc:
 
   end


### PR DESCRIPTION
@hsbt _et al._ - a minor change to `lib/rake/application.rb` which tried to declare the `FIXNUM_MAX` constant as `private`, which isn't possible in Ruby... I've replaced the `private` method call with an annotation similar to the `internal` annotation on [line 144 of that same file][one_four_four], to at least express the intent.

[one_four_four]: https://github.com/ruby/rake/blob/master/lib/rake/application.rb#L144