### PR TITLE
Define `Fixnum::MAX` constant, until such time as Ruby itself does...

### DIFF
--- a/lib/rake.rb
+++ b/lib/rake.rb
@@ -41,6 +41,7 @@ require 'ostruct'
 require 'rake/ext/module'
 require 'rake/ext/string'
 require 'rake/ext/time'
+require 'rake/ext/fixnum'
 
 require 'rake/win32'
 

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -452,7 +452,7 @@ module Rake
             "(default is number of CPU cores + 4)",
             lambda { |value|
               if value.nil? || value == ''
-                value = FIXNUM_MAX
+                value = Fixnum::MAX
               elsif value =~ /^\d+$/
                 value = value.to_i
               else
@@ -782,9 +782,6 @@ module Rake
 
       backtrace.find { |str| str =~ re } || ''
     end
-
-  private
-    FIXNUM_MAX = (2**(0.size * 8 - 2) - 1) # :nodoc:
 
   end
 end

--- a/lib/rake/ext/fixnum.rb
+++ b/lib/rake/ext/fixnum.rb
@@ -1,0 +1,18 @@
+#--
+# Extensions to fixnum to define some constants missing from Ruby itself
+
+class Fixnum
+
+  unless constants.include? :MAX
+
+    # future versions of Ruby may end up defining this constant
+    # in a more portable way, as documented by Matz himself in:
+    #
+    #   https://bugs.ruby-lang.org/issues/7517
+    #
+    # ... but until such time, we define the constant ourselves
+    MAX = (2**(0.size * 8 - 2) - 1) # :nodoc:
+
+  end
+
+end


### PR DESCRIPTION
@drbrain _et al._ - this PR moves the `FIXNUM_MAX` constant out of `lib/rake/application.rb`, and puts it in a `Fixnum` extension as `Fixnum::MAX`, which @matz himself is considering adding to Ruby:

https://bugs.ruby-lang.org/issues/7517

This is - IMHO - a much more elegant solution for the constant originally introduced in jimweirich/rake#135 and discussed - at length :smile: - in #80 

The additional benefit of this implementation is that - once Ruby defines the constant itself - `rake` will pick up the "correct" value for the constant, as opposed to the one it defines itself, which may be wrong on certain platforms.