### PR TITLE
Make Rake::Task already_invoked publicly accessible.

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -29,6 +29,10 @@ module Rake
     # location option set).
     attr_reader :locations
 
+    # Has this task already been invoked?  Already invoked tasks
+    # will be skipped unless you reenable them.
+    attr_reader :already_invoked
+
     # Return task name
     def to_s
       name

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -94,6 +94,13 @@ class TestRakeTask < Rake::TestCase
     assert_equal ["t3", "t2", "t1"], runlist
   end
 
+  def test_already_invoked
+    t1 = task(:t1) {}
+    assert_equal false, t1.already_invoked
+    t1.invoke
+    assert_equal true, t1.already_invoked
+  end
+
   def test_can_double_invoke_with_reenable
     runlist = []
     t1 = task(:t1) { |t| runlist << t.name }


### PR DESCRIPTION
It's useful to check if a Rake::Task has already been run/invoked, so
let's make this information accessible.

My use case:  I have a rake task which invokes Rails' `environment` rake task with a specific configuration so I want to raise an error if `environment` was previously run/invoked or else my rake task will become a no-op.  I'd rather not have to do this:

```ruby
raise 'xxx' if Rake::Task['environment'].instance_variable_get(:@already_invoked)`
```