### PR TITLE
Allow spaces between arguments in Rake tasks

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -84,6 +84,11 @@ module Rake
       standard_exception_handling do
         @name = app_name
         args = handle_options
+        if args.size > 1 && args.last =~ /.*\]/
+          clean_args = ""
+          args.each{ |arg| clean_args += arg }
+          args = [clean_args]
+        end
         collect_command_line_tasks(args)
       end
     end


### PR DESCRIPTION
This pull request allows input like this <code>rake my_task[arg1, arg2]</code> to be parsed correctly
instead of showing the error <code>Don't know how to build task 'mytask[arg1, '</code> as described
in https://github.com/ruby/rake/issues/85