### PR TITLE
Lookup prerequisites with same name outside of scope instead of matching self

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -54,7 +54,11 @@ module Rake
     end
 
     def lookup_prerequisite(prerequisite_name) # :nodoc:
-      application[prerequisite_name, @scope]
+      scoped_prerequisite_task = application[prerequisite_name, @scope]
+      if scoped_prerequisite_task == self
+        unscoped_prerequisite_task = application[prerequisite_name]
+      end
+      unscoped_prerequisite_task || scoped_prerequisite_task
     end
     private :lookup_prerequisite
 

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -211,6 +211,7 @@ class TestRakeTask < Rake::TestCase
   end
 
   def test_prerequisite_tasks_honors_namespaces
+    task :b
     a = b = nil
     namespace "X" do
       a = task :a => ["b", "c"]
@@ -219,6 +220,35 @@ class TestRakeTask < Rake::TestCase
     c = task :c
 
     assert_equal [b, c], a.prerequisite_tasks
+  end
+
+  def test_prerequisite_tasks_finds_tasks_with_same_name_outside_namespace
+    b1 = nil
+    namespace "a" do
+      b1 = task :b => "b"
+    end
+    b2 = task :b
+
+    assert_equal [b2], b1.prerequisite_tasks
+  end
+
+  def test_prerequisite_tasks_in_nested_namespaces
+    m = task :m
+    a_c_m = a_b_m = a_m = nil
+    namespace "a" do
+      a_m = task :m
+
+      namespace "b" do
+        a_b_m = task :m => "m"
+      end
+
+      namespace "c" do
+        a_c_m = task :m => "a:m"
+      end
+    end
+
+    assert_equal [m], a_b_m.prerequisite_tasks
+    assert_equal [a_m], a_c_m.prerequisite_tasks
   end
 
   def test_all_prerequisite_tasks_includes_all_prerequisites


### PR DESCRIPTION
Picked up from https://github.com/jimweirich/rake/pull/264

/cc @svanderbleek

I prepare to release Rake 11 and will merge this pull request.