### PR TITLE
ignored deprecated options with JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ script: ruby -Ilib bin/rake
 matrix:
   allow_failures:
     - rvm: jruby-1.7.20
-    - rvm: jruby-9.0.4.0
+    - rvm: jruby-9.0.5.0
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ rvm:
   - 2.3.0
   - ruby-head
   - jruby-1.7.20
-  - jruby-9.0.4.0
+  - jruby-9.0.5.0
   - jruby-head
   - rbx-2
 script: ruby -Ilib bin/rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ sudo: false
 notifications:
   email:
   - drbrain@segment7.net
+env:
+  global:
+    - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false"
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
travis(rvm) added deprecated option named `cext.enabled`. It shows warning message with JRuby 9.0.0.0. I eliminates it.