### PR TITLE
Replace file lists internal calls to `new` by a more generic `self.class.new`

### DIFF
--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -189,7 +189,7 @@ module Rake
       result = @items * other
       case result
       when Array
-        FileList.new.import(result)
+        self.class.new.import(result)
       else
         result
       end
@@ -235,7 +235,7 @@ module Rake
     #   FileList['a.c', 'b.c'].sub(/\.c$/, '.o')  => ['a.o', 'b.o']
     #
     def sub(pat, rep)
-      inject(FileList.new) { |res, fn| res << fn.sub(pat, rep) }
+      inject(self.class.new) { |res, fn| res << fn.sub(pat, rep) }
     end
 
     # Return a new FileList with the results of running +gsub+ against each
@@ -246,7 +246,7 @@ module Rake
     #      => ['lib\\test\\file', 'x\\y']
     #
     def gsub(pat, rep)
-      inject(FileList.new) { |res, fn| res << fn.gsub(pat, rep) }
+      inject(self.class.new) { |res, fn| res << fn.gsub(pat, rep) }
     end
 
     # Same as +sub+ except that the original file list is modified.
@@ -330,8 +330,8 @@ module Rake
       resolve
       result = @items.partition(&block)
       [
-        FileList.new.import(result[0]),
-        FileList.new.import(result[1]),
+        self.class.new.import(result[0]),
+        self.class.new.import(result[1]),
       ]
     end
 
@@ -343,7 +343,7 @@ module Rake
 
     # Add matching glob patterns.
     def add_matching(pattern)
-      FileList.glob(pattern).each do |fn|
+      self.class.glob(pattern).each do |fn|
         self << fn unless excluded_from_list?(fn)
       end
     end


### PR DESCRIPTION
Hi there,

this is a follow up of #74.

Some of file list's methods returning a new FileList instance are not returning the expected type of objects in case of inheritance from FileList. I fixed this in the mentioned PR but forgot to fix this for all methods. I apologise  for the inconvenience.

Please let me know if I should add extra tests for this. Currently I rely on the existing tests.