### PR TITLE
Correctly handle bad encoding in exception messages

### DIFF
--- a/lib/rake/trace_output.rb
+++ b/lib/rake/trace_output.rb
@@ -13,7 +13,7 @@ module Rake
       else
         output = strings.map { |s|
           next if s.nil?
-          s =~ /#{sep}$/ ? s : s + sep
+          s.end_with?(sep) ? s : s + sep
         }.join
       end
       out.print(output)

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -1,3 +1,4 @@
+#encoding: UTF-8
 require File.expand_path('../helper', __FILE__)
 
 class TestRakeApplication < Rake::TestCase
@@ -32,6 +33,20 @@ class TestRakeApplication < Rake::TestCase
 
     assert_match 'rake aborted!', err
     assert_match __method__.to_s, err
+  end
+
+  def test_display_exception_details_bad_encoding
+    begin
+      raise 'El Niño is coming!'.force_encoding('US-ASCII')
+    rescue => ex
+    end
+
+    out, err = capture_io do
+      @app.display_error_message ex
+    end
+
+    assert_empty out
+    assert_match 'El Niño is coming!', err.force_encoding('UTF-8')
   end
 
   def test_display_exception_details_cause


### PR DESCRIPTION
TraceOutput#trace_on has a bug that causes the matching to fail if a string is incorrectly encoded - for example encoded as 'US-ASCII' but contains unicode characters. This causes a new exception to be thrown, losing the stack trace of the previous exception.
This can occur, for example, in Ruby 1.9 when one of the dependencies of a project includes a file that contains unicode but does not specify an encoding (as the default for Ruby 1.9 is US-ASCII). 
This was the case in a certain version of the Puma web server, which was fixed in https://github.com/puma/puma/pull/924 but was very difficult to debug  due to the incorrect stack trace provided by rake.