### PR TITLE
Add possibility to specify test task prerequisites

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -69,6 +69,9 @@ module Rake
     # Description of the test task. (default is 'Run tests')
     attr_accessor :description
 
+    # Task prerequisites.
+    attr_accessor :deps
+
     # Explicitly define the list of test files to be included in a
     # test.  +list+ is expected to be an array of file names (a
     # FileList is acceptable).  If both +pattern+ and +test_files+ are
@@ -89,6 +92,7 @@ module Rake
       @loader = :rake
       @ruby_opts = []
       @description = "Run tests" + (@name == :test ? "" : " for #{@name}")
+      @deps = []
       yield self if block_given?
       @pattern = 'test/test*.rb' if @pattern.nil? && @test_files.nil?
       define
@@ -97,7 +101,7 @@ module Rake
     # Create the tasks defined by this task lib.
     def define
       desc @description
-      task @name do
+      task @name => Array(deps) do
         FileUtilsExt.verbose(@verbose) do
           args =
             "#{ruby_opts_string} #{run_code} " +

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -12,6 +12,7 @@ class TestRakeTestTask < Rake::TestCase
     assert_equal 'test/test*.rb', tt.pattern
     assert_equal false, tt.verbose
     assert_equal true, tt.warning
+    assert_equal [], tt.deps
     assert Task.task_defined?(:test)
   end
 
@@ -22,6 +23,7 @@ class TestRakeTestTask < Rake::TestCase
       t.pattern = 'test/tc_*.rb'
       t.warning = true
       t.verbose = true
+      t.deps = [:env]
     end
     refute_nil tt
     assert_equal "Run example tests", tt.description
@@ -30,6 +32,7 @@ class TestRakeTestTask < Rake::TestCase
     assert_equal 'test/tc_*.rb', tt.pattern
     assert_equal true, tt.warning
     assert_equal true, tt.verbose
+    assert_equal [:env], tt.deps
     assert_match(/-w/, tt.ruby_opts_string)
     assert_match(/--verbose/, tt.ruby_opts_string)
     assert Task.task_defined?(:example)
@@ -127,5 +130,16 @@ class TestRakeTestTask < Rake::TestCase
     end
 
     assert_equal ["a.rb", 'b.rb'], tt.file_list.to_a
+  end
+
+  def test_task_prerequisites
+    Rake::TestTask.new :parent
+
+    Rake::TestTask.new :child do |t|
+      t.deps = :parent
+    end
+
+    task = Rake::Task[:child]
+    assert_includes task.prerequisites, 'parent'
   end
 end


### PR DESCRIPTION
This PR allows to specify dependencies(prerequisites) for test task
```ruby
Rake::TestTask.new do |t|
  t.deps = :setup
end
```