### PR TITLE
Fix verbose under JRuby

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -128,7 +128,13 @@ module Rake
       opts = @ruby_opts.dup
       opts.unshift("-I\"#{lib_path}\"") unless @libs.empty?
       opts.unshift("-w") if @warning
-      opts.unshift('--verbose') if @verbose
+      if @verbose
+        if defined?(JRUBY_VERSION)
+          opts.unshift('-v')
+        else
+          opts.unshift('--verbose')
+        end
+      end
       opts.join(" ")
     end
 

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -31,7 +31,11 @@ class TestRakeTestTask < Rake::TestCase
     assert_equal true, tt.warning
     assert_equal true, tt.verbose
     assert_match(/-w/, tt.ruby_opts_string)
-    assert_match(/--verbose/, tt.ruby_opts_string)
+    if jruby?
+      assert_match(/-v/, tt.ruby_opts_string)
+    else
+      assert_match(/--verbose/, tt.ruby_opts_string)
+    end
     assert Task.task_defined?(:example)
   end
 


### PR DESCRIPTION
Under JRuby, using `rake/testtask` with the verbose flag broke:
"jruby: unknown option --verbose"

The error in a Travis test run:
https://travis-ci.org/appneta/ruby-traceview/jobs/115183595

`--verbose` isn't a valid command line option for the jruby binary.  It uses `-v`.

This pull request is to use `-v` instead when running under JRuby.