### PR TITLE
JRuby 9.0.4 not support --verbose, so skip unshift --verbose

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -128,7 +128,7 @@ module Rake
       opts = @ruby_opts.dup
       opts.unshift("-I\"#{lib_path}\"") unless @libs.empty?
       opts.unshift("-w") if @warning
-      opts.unshift('--verbose') if @verbose
+      opts.unshift('--verbose') if @verbose && !defined?(JRUBY_VERSION)
       opts.join(" ")
     end
 

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -31,7 +31,7 @@ class TestRakeTestTask < Rake::TestCase
     assert_equal true, tt.warning
     assert_equal true, tt.verbose
     assert_match(/-w/, tt.ruby_opts_string)
-    assert_match(/--verbose/, tt.ruby_opts_string)
+    assert_match(/--verbose/, tt.ruby_opts_string) unless defined?(JRUBY_VERSION)
     assert Task.task_defined?(:example)
   end
 


### PR DESCRIPTION
To resolve [active_model_serializers PR 1585](https://github.com/rails-api/active_model_serializers/pull/1585).

rake test —verbose is introduce at
https://github.com/ruby/rake/commit/6495738dbc3468ea400eec983746cb49ef6226cc
