### PR TITLE
Remove -W option on TestTask

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,10 @@
+=== 11.1.2 / 2016-03-28
+
+Bug fixes:
+
+* Remove `-W` option when Rake::TestTask#verbose enabled. It's misunderstanding
+  specification change with Rake 11. Partly revert #67
+
 === 11.1.1 / 2016-03-14
 
 Bug fixes:

--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -128,7 +128,6 @@ module Rake
       opts = @ruby_opts.dup
       opts.unshift("-I\"#{lib_path}\"") unless @libs.empty?
       opts.unshift("-w") if @warning
-      opts.unshift('-W') if @verbose
       opts.join(" ")
     end
 

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -31,7 +31,6 @@ class TestRakeTestTask < Rake::TestCase
     assert_equal true, tt.warning
     assert_equal true, tt.verbose
     assert_match(/-w/, tt.ruby_opts_string)
-    assert_match(/-W/, tt.ruby_opts_string)
     assert Task.task_defined?(:example)
   end
 


### PR DESCRIPTION
It's unexpected change from Rake 10. Fixes https://github.com/ruby/rake/issues/125