### PR TITLE
Removed needless requires

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -1,4 +1,3 @@
-require 'shellwords'
 require 'optparse'
 
 require 'rake/task_manager'

--- a/lib/rake/rake_test_loader.rb
+++ b/lib/rake/rake_test_loader.rb
@@ -19,4 +19,3 @@ argv = ARGV.select do |argument|
 end
 
 ARGV.replace argv
-

--- a/lib/rake/rule_recursion_overflow_error.rb
+++ b/lib/rake/rule_recursion_overflow_error.rb
@@ -1,4 +1,3 @@
-
 module Rake
 
   # Error indicating a recursion overflow error in task selection.

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -1,4 +1,3 @@
-require 'thread'
 require 'set'
 
 require 'rake/promise'


### PR DESCRIPTION
* shellwords is not use in Rake 11
* thread is already core library. Not necessary for using it