### PR TITLE
Update comment parsing rules

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -304,10 +304,10 @@ module Rake
     private :transform_comments
 
     # Get the first sentence in a string. The sentence is terminated
-    # by the first period or the end of the line. Decimal points do
-    # not count as periods.
+    # by the first period, exclamation mark, or the end of the line.
+    # Decimal points do not count as periods.
     def first_sentence(string)
-      string.split(/\.[ \t]|\.$|\n/).first
+      string.split(/(?<=\w)(\.|!)[ \t]|(\.$|!)|\n/).first
     end
     private :first_sentence
 

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -352,10 +352,22 @@ class TestRakeTask < Rake::TestCase
     assert_equal "A Comment", t.comment
   end
 
-  def test_comments_with_sentences
+  def test_comments_with_sentences_period
     desc "Comment 1. Comment 2."
     t = task(:t, :name, :rev)
     assert_equal "Comment 1", t.comment
+  end
+
+  def test_comments_with_sentences_exclamation_mark
+    desc "An exclamation mark! Comment."
+    t = task(:t, :name, :rev)
+    assert_equal "An exclamation mark", t.comment
+  end
+
+  def test_comments_with_many_periods
+    desc "This is a test...I think ... testing. Comment."
+    t = task(:t, :name, :rev)
+    assert_equal "This is a test...I think ... testing", t.comment
   end
 
   def test_comments_with_tabbed_sentences


### PR DESCRIPTION
Closes https://github.com/ruby/rake/issues/106. Also makes `first_sentence` lookout for exclamation marks. For example:

```
# task name is testing
desc "This drops your database! Make sure you've backed up your db."
```

Running `rake -T` will show
`rake testing            # This drops your database`