### PR TITLE
Don't set if args are blank

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -17,7 +17,8 @@ module Rake
       @hash = {}
       @values = values
       names.each_with_index { |name, i|
-        @hash[name.to_sym] = values[i] unless values[i].nil?
+        next if values[i].nil? || values[i] == ''
+        @hash[name.to_sym] = values[i]
       }
     end
 

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -19,6 +19,11 @@ class TestRakeTaskArguments < Rake::TestCase
     assert_equal({:a => :one, :b => :two, :c => :three}, ta.to_hash)
   end
 
+  def test_blank_values_in_args
+    ta = Rake::TaskArguments.new([:a, :b, :c], ['', :two, ''])
+    assert_equal({:b => :two}, ta.to_hash)
+  end
+
   def test_has_key
     ta = Rake::TaskArguments.new([:a], [:one])
     assert(ta.has_key?(:a))


### PR DESCRIPTION
I want to change the action of named arguments #with_defaults.
followings are example.
```
# rake file
task :some_task => [:a, :b] do |task, args|
  args.with_defaults({a: 'a', b: 'b'})
  p args.to_hash
end

# execute(now master)
rake some_task[,c]  # => {:a=>"", :b=>"c"}

# execute(expected)
rake some_task[,c]  # =>  {:a=>"a", :b=>"c"}
```
Rake::TaskArguments are separated by comma, so when I want default value for `:a` but specify for `:b`, want to use arguments `[,any]`.

Please let me know if any problems, I will fix my code and resend pull request.