### PR TITLE
Spawn options for sh

### DIFF
--- a/lib/rake/file_utils.rb
+++ b/lib/rake/file_utils.rb
@@ -48,7 +48,7 @@ module FileUtils
     set_verbose_option(options)
     options[:noop] ||= Rake::FileUtilsExt.nowrite_flag
     Rake.rake_check_options options, :noop, :verbose
-    Rake.rake_output_message cmd.join(" ") if options[:verbose]
+    Rake.rake_output_message sh_show_command cmd if options[:verbose]
 
     unless options[:noop]
       res = system(*cmd)
@@ -59,8 +59,9 @@ module FileUtils
   end
 
   def create_shell_runner(cmd) # :nodoc:
-    show_command = cmd.join(" ")
+    show_command = sh_show_command cmd
     show_command = show_command[0, 42] + "..." unless $trace
+
     lambda do |ok, status|
       ok or
         fail "Command failed with status (#{status.exitstatus}): " +
@@ -68,6 +69,19 @@ module FileUtils
     end
   end
   private :create_shell_runner
+
+  def sh_show_command(cmd) # :nodoc:
+    cmd = cmd.dup
+
+    if Hash === cmd.first
+      env = cmd.first
+      env = env.map { |name, value| "#{name}=#{value}" }.join " "
+      cmd[0] = env
+    end
+
+    cmd.join " "
+  end
+  private :sh_show_command
 
   def set_verbose_option(options) # :nodoc:
     unless options.key? :verbose

--- a/lib/rake/file_utils.rb
+++ b/lib/rake/file_utils.rb
@@ -45,13 +45,15 @@ module FileUtils
   def sh(*cmd, &block)
     options = (Hash === cmd.last) ? cmd.pop : {}
     shell_runner = block_given? ? block : create_shell_runner(cmd)
-    set_verbose_option(options)
-    options[:noop] ||= Rake::FileUtilsExt.nowrite_flag
-    Rake.rake_check_options options, :noop, :verbose
-    Rake.rake_output_message sh_show_command cmd if options[:verbose]
 
-    unless options[:noop]
-      res = system(*cmd)
+    set_verbose_option(options)
+    verbose = options.delete :verbose
+    noop    = options.delete(:noop) || Rake::FileUtilsExt.nowrite_flag
+
+    Rake.rake_output_message sh_show_command cmd if verbose
+
+    unless noop
+      res = system(*cmd, options)
       status = $?
       status = Rake::PseudoStatus.new(1) if !res && status.nil?
       shell_runner.call(res, status)

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -164,6 +164,20 @@ class TestRakeFileUtils < Rake::TestCase
     }
   end
 
+  def test_sh_with_spawn_options
+    echocommand
+
+    r, w = IO.pipe
+
+    verbose(false) {
+      sh RUBY, 'echocommand.rb', out: w
+    }
+
+    w.close
+
+    assert_equal "echocommand.rb\n", r.read
+  end
+
   def test_sh_failure
     shellcommand
 
@@ -323,6 +337,16 @@ else
   exit 0
 end
     CHECK_EXPANSION
+  end
+
+  def echocommand
+    command 'echocommand.rb', <<-ECHOCOMMAND
+#!/usr/bin/env ruby
+
+puts "echocommand.rb"
+
+exit 0
+    ECHOCOMMAND
   end
 
   def replace_ruby

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -165,6 +165,8 @@ class TestRakeFileUtils < Rake::TestCase
   end
 
   def test_sh_with_spawn_options
+    skip 'JRuby does not support spawn options' if jruby?
+
     echocommand
 
     r, w = IO.pipe
@@ -213,6 +215,10 @@ class TestRakeFileUtils < Rake::TestCase
   end
 
   def test_sh_bad_option
+    # Skip on JRuby because option checking is performed by spawn via system
+    # now.
+    skip 'JRuby does not support spawn options' if jruby?
+
     shellcommand
 
     ex = assert_raises(ArgumentError) {

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -141,6 +141,18 @@ class TestRakeFileUtils < Rake::TestCase
     }
   end
 
+  def test_sh_with_env
+    check_environment
+
+    env = {
+      'RAKE_TEST_SH' => 'someval'
+    }
+
+    verbose(false) {
+      sh env, RUBY, 'check_environment.rb', 'RAKE_TEST_SH', 'someval'
+    }
+  end
+
   def test_sh_with_multiple_arguments
     skip if jruby9? # https://github.com/jruby/jruby/issues/3653
 
@@ -241,6 +253,20 @@ class TestRakeFileUtils < Rake::TestCase
     }
   end
 
+  def test_sh_show_command
+    env = {
+      'RAKE_TEST_SH' => 'someval'
+    }
+
+    cmd = [env, RUBY, 'some_file.rb', 'some argument']
+
+    show_cmd = send :sh_show_command, cmd
+
+    expected_cmd = "RAKE_TEST_SH=someval #{RUBY} some_file.rb some argument"
+
+    assert_equal expected_cmd, show_cmd
+  end
+
   def test_ruby_with_multiple_arguments
     skip if jruby9? # https://github.com/jruby/jruby/issues/3653
 
@@ -277,6 +303,16 @@ else
   exit 1
 end
     CHECK_EXPANSION
+  end
+
+  def check_environment
+    command 'check_environment.rb', <<-CHECK_ENVIRONMENT
+if ENV[ARGV[0]] != ARGV[1]
+  exit 1
+else
+  exit 0
+end
+    CHECK_ENVIRONMENT
   end
 
   def check_expansion


### PR DESCRIPTION
This allows any spawn option to be used with `sh`.

This also improves the printed command output when an ENV hash is supplied.