### PR TITLE
Remove mention of environment variables as task argument.

### DIFF
--- a/doc/rakefile.rdoc
+++ b/doc/rakefile.rdoc
@@ -223,9 +223,7 @@ behaviour can now accept a second parameter:
 The first argument of the block "t" is always bound to the current
 task object.  The second argument "args" is an open-struct like object
 that allows access to the task arguments.  Extra command line
-arguments to a task are ignored.  Missing command line arguments are
-picked up from matching environment variables.  If there are no
-matching environment variables, they are given the nil value.
+arguments to a task are ignored.
 
 If you wish to specify default values for the arguments, you can use
 the with_defaults method in the task body.  Here is the above example


### PR DESCRIPTION
Related to commit 57cdf0fafb85c9f4efbcd871e094686fdc2ca753.

Support for environment variables as task argument was removed on
commit 5148aac8b61246432d6d87f19f26e401ace62853.