### PR TITLE
Remove trailing slash on a link in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 home :: https://github.com/ruby/rake
 bugs :: https://github.com/ruby/rake/issues
-docs :: http://docs.seattlerb.org/rake/
+docs :: http://docs.seattlerb.org/rake
 build status :: {<img src="https://travis-ci.org/ruby/rake.svg?branch=master" alt="travis-ci">}[https://travis-ci.org/ruby/rake] {<img src="https://ci.appveyor.com/api/projects/status/github/ruby/rake?branch=master&svg=true" alt="appveyor">}[https://ci.appveyor.com/project/ruby/rake]
 
 == Description


### PR DESCRIPTION
Otherwise:

<img width="313" alt="screen shot 2016-06-26 at 00 20 19" src="https://cloud.githubusercontent.com/assets/113730/16360475/e22b7d8c-3b33-11e6-874b-ab1989dfe969.png">

Note the trailing slash not being part of the link nor the label.
I couldn't help myself not to see this 😄 