### PR TITLE
Sh fully echoes commands which error exit

### DIFF
--- a/lib/rake/file_utils.rb
+++ b/lib/rake/file_utils.rb
@@ -62,8 +62,6 @@ module FileUtils
 
   def create_shell_runner(cmd) # :nodoc:
     show_command = sh_show_command cmd
-    show_command = show_command[0, 42] + "..." unless $trace
-
     lambda do |ok, status|
       ok or
         fail "Command failed with status (#{status.exitstatus}): " +

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -287,6 +287,49 @@ class TestRakeFileUtils < Rake::TestCase
     assert_equal expected_cmd, show_cmd
   end
 
+  def test_sh_if_a_command_exits_with_error_status_its_full_output_is_printed
+    verbose false do
+      standard_output = 'Some output'
+      standard_error  = 'Some error'
+      shell_command = "ruby -e\"puts '#{standard_output}';STDERR.puts '#{standard_error}';exit false\""
+      actual_both = capture_subprocess_io do
+        begin
+          sh shell_command
+        rescue
+        else
+          flunk
+        end
+      end
+      actual = actual_both.join
+      assert_match standard_output, actual
+      assert_match standard_error,  actual
+    end
+  end
+
+  def test_sh_if_a_command_exits_with_error_status_sh_echoes_it_fully
+    verbose true do
+      assert_echoes_fully
+    end
+    verbose false do
+      assert_echoes_fully
+    end
+  end
+
+  def assert_echoes_fully
+    long_string = '1234567890' * 10
+    shell_command = "ruby -e\"'#{long_string}';exit false\""
+    capture_subprocess_io do
+      begin
+        sh shell_command
+      rescue => ex
+        assert_match 'Command failed with status', ex.message
+        assert_match shell_command, ex.message
+      else
+        flunk
+      end
+    end
+  end
+
   def test_ruby_with_multiple_arguments
     skip if jruby9? # https://github.com/jruby/jruby/issues/3653
 


### PR DESCRIPTION
CASE

`FileUtils#sh` truncates (to 42 characters) the echoing of failed shelled-out commands (as determined by their exit status). (BTW, even when the output is redirected to a file, it still truncates, in the same way.)

This isn't about shelled-out commands that _succeed_.

Why truncate the failed ones, anyhow? (And why to 42 characters?) What's the reason or rationale?

Every user wants to know (presumably) exactly which failed command their program was unable to handle, in order to obtain help to make their program work.

Passing a block to `FileUtils#sh` can avoid echoing any failed command, easily. So, any wish to provide some facility to avoid excessive echoing doesn't fully seem to justify this truncation.

This truncation of failed commands seems devoid of test coverage (because, if I comment [this](https://github.com/ruby/rake/blob/226b8a0dbfca92dfb4202dcf589b53400584d6f3/lib/rake/file_utils.rb#L65) out, all tests still pass).

(BTW, the truncation seems related to `ENV['RAKE_COLUMNS']`, `@terminal_columns`, `terminal_width()`, and `truncate_output?()`.)

If a program contains long shell commands (which incorporate fully-qualified paths), and if one of them fails, then 42 characters seems unhelpful.

I've been using a program which runs various program-generation recipes. Relatively unsophisticated people use it. It's (arguably) a good representative of a whole category of programs using Rake's `FileUtils#sh`.

Usually, when the program I'm using fails (because of external circumstances), the users don't rerun the program with `--trace` (despite Rake's recommendation—perhaps because the program is long-running) but instead simply submit the output as they first received it. And they themselves can't see the full, shelled-out command.

As a result, typically the (relatively newby) users aren't submitting the full details of the generated, failed shelled-out commands in their error reports—far from it. At that point, we typically ask them to rerun the program with `--trace`. Typically this delays our troubleshooting by one or more email cycles, or in some cases even blocks our users (they give up).

PLAN

Of course, I believe the program I'm using (and others like it—see above) should continue to use `FileUtils#sh`, yet (somehow) I'd like to influence this 42-character truncation.

I'd like to remove it.

Even if the truncation were to remain, then I'd like to be able to configure the 42 programmatically, perhaps with a Rake constant. Perhaps 0 (zero) could mean: don't truncate the command at all (for example).

For this purpose, a Rake command-line option would *not* be useful, because already the (relatively newby) users (of programs like the one mentioned above) don't use `--trace`.

Instead, because the relevant, shelled-out commands have failed, I believe they should be echoed in their entirety in any case. Does that make sense?

This pull request accomplishes this last goal. And it includes new tests to cover it.

HISTORY

2005-04-09 7:41:05 "updated changes" commit 5a3950dd2963ca3e6d3d2733b1173e7d01580aa1 (toward Rake 0.5.3, and apparently referring to the later 7:41:07 change). File `rake/CHANGES` says "Fixed verbose flag bug in the testing task. Shortened some failure messages."

2005-04-09 7:41:07 "shortened error on task failure" commit f022aee7b2c3bbe7e6f3439ee59c08fd069b1af4. File `rake/lib/rake.rb` began [truncating](https://github.com/ruby/rake/commit/f022aee7b2c3bbe7e6f3439ee59c08fd069b1af4#diff-2207db2581c2ae9b8f98458070ad8b44R483) echoed failed commands to 42 characters.

2005-04-09 8:43 "updated documentation" commit cdd66db2459cbb29e6a51b5be505b038a03dcf58. File `rake/doc/release_notes/rake-0.5.3.rdoc` says "Fixed the verbose flag in the TestTask so that the test code is controlled by the flag.  Also shortened up some failure messages. (Thanks to Tobias Luetke for the suggestion.)" (BTW, I believe this is @tobi.)

2006-08-12 "removed nested directory from CVS conversion" commit 8f9da2e095d4016849a896da14b96ceeab0080a2 (toward Rake 0.7.1.3). Renamed file `rake/lib/rake.rb` to `lib/rake.rb`.

2007-03-31 "added existing and existing! methods to FileList" commit 0c5500a0f7a0fa73061a9f96fc33be4064b28c45 (toward Rake 0.7.3). File `lib/rake.rb` began [appending](https://github.com/ruby/rake/commit/0c5500a0f7a0fa73061a9f96fc33be4064b28c45#diff-26729347a9c3b31c5c9f4305f965d8e3R728) "..." always to echoed, failed commands (even to short ones). It also [added](https://github.com/ruby/rake/commit/0c5500a0f7a0fa73061a9f96fc33be4064b28c45#diff-26729347a9c3b31c5c9f4305f965d8e3R729) a TODO, apparently for further investigation. The TODO includes the mysterious abbreviation "heref" (perhaps meaning "heretofore").

2009-03-06 "show all of the sh command if in trace mode" commit 14a4c32449867f0c61d74ab99cdb0820d4df73cf (toward Rake 0.8.4.99). [Initiated](https://github.com/ruby/rake/commit/14a4c32449867f0c61d74ab99cdb0820d4df73cf#diff-26729347a9c3b31c5c9f4305f965d8e3R963) truncation unless in trace mode.

2009-03-28 "moved FileList to a separate file" commit 0d4416efd91808320323936f21f58fc64c695187 (toward Rake 0.8.5). Created file `lib/rake/file_utils.rb`, and moved method `sh` to it (from `lib/rake.rb`).

2009-05-24 22:45 "fixed problem with :verbose=>false in sh and ruby commands" commit 6afd6faeee1c39868748f2b8f001e6d627919b49 (toward Rake 0.8.99.1). (This doesn't tell us much.)

2009-05-24 23:05 "refactoring the sh command a bit" commit 5f525246d044c483002cc55930d42a40faca07d5. File `lib/rake/file_utils.rb` [removed](https://github.com/ruby/rake/commit/5f525246d044c483002cc55930d42a40faca07d5#diff-f7fcb87d482d055b9df1e86fd76ae06fL35) the TODO; the relevant code was [moved](https://github.com/ruby/rake/commit/5f525246d044c483002cc55930d42a40faca07d5#diff-f7fcb87d482d055b9df1e86fd76ae06fR45) to a new private method `create_shell_command`, which still truncates failed command echoing to 42 characters.

2009-05-24 23:12 "changed nomenclature from shell_command to shell_runner" commit 2865311c66078d6b2b334413c7d7f7d99653e5dd. [Changed](https://github.com/ruby/rake/commit/2865311c66078d6b2b334413c7d7f7d99653e5dd#diff-f7fcb87d482d055b9df1e86fd76ae06fR45) the method name to (the current) `create_shell_runner`.