### PR TITLE
TestTask when --verbose prompts for TESTOPTS="--verbose"

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -107,6 +107,8 @@ module Rake
       desc @description
       task @name => Array(deps) do
         FileUtilsExt.verbose(@verbose) do
+          puts "Use TESTOPTS=\"--verbose\" to pass --verbose" \
+            ", etc. to runners." if ARGV.include? '--verbose'
           args =
             "#{ruby_opts_string} #{run_code} " +
             "#{file_list_string} #{option_list}"

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -49,6 +49,16 @@ end
     RAKEFILE
   end
 
+  def rakefile_test_task_verbose
+    rakefile <<-RAKEFILE
+    require "rake/testtask"
+
+    Rake::TestTask.new(:unit) do |t|
+      t.verbose = true
+    end
+    RAKEFILE
+  end
+
   def rakefile_chains
     rakefile <<-DEFAULT
 task :default => "play.app"

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -384,6 +384,20 @@ class TestRakeFunctional < Rake::TestCase
     assert_match(/custom test task description/, @out)
   end
 
+  def test_test_task_when_verbose_unless_verbose_passed_not_prompt_testopts
+    rakefile_test_task_verbose
+    rake 'unit'
+    exp = /TESTOPTS="--verbose" to pass --verbose/
+    refute_match exp, @out
+  end
+
+  def test_test_task_when_verbose_passed_prompts_testopts
+    rakefile_test_task
+    rake '--verbose', 'unit'
+    exp = /TESTOPTS="--verbose" to pass --verbose/
+    assert_match exp, @out
+  end
+
   def test_comment_before_task_acts_like_desc
     rakefile_comments
 


### PR DESCRIPTION
CASE

Originally, Jim Weirich developed Rake to work with (arguably) `Test::Unit`, before the arrival of `Minitest`. And none of the following gems:
* `Cucumber`
* `RSpec`
* `Test::Unit`

(used for testing) prompts the user to rerun their tests with a `--verbose` command line option.

`Minitest` (somewhat newer) does so prompt the user—it (sometimes) emits the message: "You have skipped tests. Run with `--verbose` for details." Under Rake, this message is somewhat confusing. This has been reported (see below).

Rake's own test suite employs `Minitest`. When tests are skipped (as on `Windows`), it also displays this problem (i.e., `Minitest` emits the above, confusing message).

In a Rails issue, [Adding --verbose flag to rake test doesn't do anything](https://github.com/rails/rails/issues/13641#issuecomment-32492973) (closed), @cannikin says:

> Maybe the Rake test output should be updated to mention [TESTOPTS='v'] instead of --verbose? I know the message is coming from Minitest, which doesn't know/care that it's running inside a Rake task, but I doubt the average person running tests from the console would know that.

In an (earlier) article, [Rails Tip: Running Tests with Verbose Output](http://marklunds.com/articles/one/414), @peter says:

> It took me a while to track down the TESTOPTS argument.

Overall, it would seem good to improve the ease (for new users) of using Rake's `TestTask`.

PLAN

In @shunsuke227ono's `Minitest` pull request, [add summary message for case that minitest is used from rake task](https://github.com/seattlerb/minitest/pull/564) (closed), @zenspider [commented](https://github.com/seattlerb/minitest/pull/564#issuecomment-203153058):

> I'm not sure I agree with the sentiment of this PR. What about all the other ways that tests might be run? I don't think minitest should try to cover them all. It is the responsibility of the developer to know their tools, not minitest.

It seems possible (though elaborately difficult) for Rake to detect Minitest (despite its being run in a forked shell command).

But to avoid all that (major) trouble, simply supplying a printed reminder to use `TESTOPTS="--verbose"` would seem able to clarify this instead (for new users), as well as to resolve this misleading information apparently printed by a Rake test task.

To minimize output, this should be printed only when running a Rake `TestTask` in `--verbose` mode (e.g., when the user already has tried the `Minitest`-recommended solution of adding `--verbose`).

This supplies that printed reminder (and adds tests). It ameliorates the issue of (the effectively reverted) pull request #67.