### PR TITLE
remove obsolete OPT_TABLE entries

### DIFF
--- a/lib/rake/file_utils.rb
+++ b/lib/rake/file_utils.rb
@@ -11,9 +11,6 @@ module FileUtils
     RbConfig::CONFIG["ruby_install_name"] + RbConfig::CONFIG["EXEEXT"]).
     sub(/.*\s.*/m, '"\&"')
 
-  OPT_TABLE["sh"]  = %w(noop verbose)
-  OPT_TABLE["ruby"] = %w(noop verbose)
-
   # Run the system command +cmd+.  If multiple arguments are given the command
   # is run directly (without the shell, same semantics as Kernel::exec and
   # Kernel::system).


### PR DESCRIPTION
As of #138, the `OPT_TABLE` entries for `sh` and `ruby` are no longer used internally, and a GitHub search for these entries suggests that they are not used externally: https://git.io/v6hpi