### PR TITLE
Fix test fail caused by bundler-1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - jruby-9.1.0.0
   - jruby-head
 before_install:
+  - gem update --system
   - gem install bundler --no-document
 before_script:
   - unset JRUBY_OPTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ rvm:
   - jruby-9.1.0.0
   - jruby-head
 before_install:
-  - gem uninstall bundler
-  - gem install bundler -v '~> 1.12.5' --no-document
-
+  - gem install bundler --no-document
 before_script:
   - unset JRUBY_OPTS
 script: ruby -Ilib exe/rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - jruby-9.1.0.0
   - jruby-head
 before_install:
-  - gem install bundler -v '~> 1.12.5' --no-document
+  - gem install bundler --no-document
 before_script:
   - unset JRUBY_OPTS
 script: ruby -Ilib exe/rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - jruby-9.1.0.0
   - jruby-head
 before_install:
-  - gem install bundler --no-document
+  - gem install bundler -v '~> 1.12.5' --no-document
 before_script:
   - unset JRUBY_OPTS
 script: ruby -Ilib exe/rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - jruby-9.1.0.0
   - jruby-head
 before_install:
+  - gem uninstall bundler
   - gem install bundler -v '~> 1.12.5' --no-document
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ rvm:
   - jruby-9.1.0.0
   - jruby-head
 before_install:
-  - gem update --system
-  - gem install bundler --no-document
+  - gem install bundler -v '~> 1.12.5' --no-document
+
 before_script:
   - unset JRUBY_OPTS
 script: ruby -Ilib exe/rake

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,9 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+# XXX: https://github.com/bundler/bundler/pull/4981
+require "bundler/plugin/api/source"
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "rdoc/task"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ build_script:
   - net localgroup
 test_script:
   - ruby -Ilib exe/rake
-
 environment:
   matrix:
     - ruby_version: "193"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,8 @@ clone_depth: 10
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
-  - gem update --system
   - gem --version
-  - gem install minitest --no-document
+  - gem install minitest bundler --no-document
 build_script:
   - net user
   - net localgroup


### PR DESCRIPTION
bundler-1.13.0 references `Gem::Source`. It is only provided from rubygems-2.6.x