### PR TITLE
show extended output on testtask fail only with verbose or trace

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -118,7 +118,14 @@ module Rake
             elsif !ok
               status  = "Command failed with status (#{status.exitstatus})"
               details = ": [ruby #{args}]"
-              fail (ARGV.include?('--trace') || @verbose) ? (status + details) : status
+              message =
+                if Rake.application.options.trace or @verbose then
+                  status + details
+                else
+                  status
+                end
+
+              fail message
             end
           end
         end

--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -116,8 +116,9 @@ module Rake
             if !ok && status.respond_to?(:signaled?) && status.signaled?
               raise SignalException.new(status.termsig)
             elsif !ok
-              fail "Command failed with status (#{status.exitstatus}): " +
-                "[ruby #{args}]"
+              status  = "Command failed with status (#{status.exitstatus})"
+              details = ": [ruby #{args}]"
+              fail (ARGV.include?('--trace') || @verbose) ? (status + details) : status
             end
           end
         end


### PR DESCRIPTION
When using Rake::TestTask with a lot of files at once, sometimes the failure output from rake is quite overwhelming (because of the file list appended to the message "Command failed with status..."). This commit only shows that extended information if the user asks for verbose output in the Rake::TestTask or uses the --trace command when invoking rake.