### PR TITLE
Respect trace option in cleanup

### DIFF
--- a/lib/rake/clean.rb
+++ b/lib/rake/clean.rb
@@ -29,6 +29,7 @@ module Rake
 
     def cleanup(file_name, opts={})
       begin
+        opts = {:verbose => Rake.application.options.trace}.merge(opts)
         rm_r file_name, opts
       rescue StandardError => ex
         puts "Failed to remove #{file_name}: #{ex}" unless file_already_gone?(file_name)

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -32,7 +32,55 @@ class TestRakeClean < Rake::TestCase
     refute_match(/failed to remove/i, out)
   end
 
+  def test_cleanup_trace
+    file_name = create_file
+
+    assert_output "", "rm -r #{file_name}\n" do
+      with_trace true do
+        Rake::Cleaner.cleanup(file_name)
+      end
+    end
+  end
+
+  def test_cleanup_without_trace
+    file_name = create_file
+
+    assert_output "", "" do
+      with_trace false do
+        Rake::Cleaner.cleanup(file_name)
+      end
+    end
+  end
+
+  def test_cleanup_opt_overrides_trace_silent
+    file_name = create_file
+
+    assert_output "", "" do
+      with_trace true do
+        Rake::Cleaner.cleanup(file_name, verbose: false)
+      end
+    end
+  end
+
+  def test_cleanup_opt_overrides_trace_verbose
+    file_name = create_file
+
+    assert_output "", "rm -r #{file_name}\n" do
+      with_trace false do
+        Rake::Cleaner.cleanup(file_name, verbose: true)
+      end
+    end
+  end
+
   private
+
+  def create_file
+    dir_name = File.join(@tempdir, "deletedir")
+    file_name = File.join(dir_name, "deleteme")
+    FileUtils.mkdir(dir_name)
+    FileUtils.touch(file_name)
+    file_name
+  end
 
   def create_undeletable_file
     dir_name = File.join(@tempdir, "deletedir")
@@ -57,5 +105,17 @@ class TestRakeClean < Rake::TestCase
     FileUtils.chmod(0777, file_name)
     Rake::Cleaner.cleanup(file_name, verbose: false)
     Rake::Cleaner.cleanup(dir_name, verbose: false)
+  end
+
+  def with_trace value
+    old, Rake.application.options.trace =
+      Rake.application.options.trace, value
+
+    # FileUtils caches the $stderr object, which breaks capture_io et. al.
+    # We hack it here where it's convenient to do so.
+    Rake::Cleaner.instance_variable_set :@fileutils_output, nil
+    yield
+  ensure
+    Rake.application.options.trace = old
   end
 end

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -46,7 +46,7 @@ class TestRakeClean < Rake::TestCase
     rescue
       file_name
     else
-      skip "Permission to delete files is different on thie system"
+      skip "Permission to delete files is different on this system"
     end
   end
 


### PR DESCRIPTION
I had to hack FileUtils a little to get the test suite to pass.
I'm wondering if this should be a bug reported upstream.