### PR TITLE
fix to_hash bug

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -68,7 +68,7 @@ module Rake
 
     # Returns a Hash of arguments and their values
     def to_hash
-      @hash
+      @hash.dup
     end
 
     def to_s # :nodoc:

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -284,6 +284,8 @@ class TestRakeApplication < Rake::TestCase
   end
 
   def test_load_rakefile_not_found
+    skip if jruby9?
+
     ARGV.clear
     Dir.chdir @tempdir
     ENV["RAKE_SYSTEM"] = "not_exist"

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -122,6 +122,8 @@ class TestRakeFunctional < Rake::TestCase
   end
 
   def test_implicit_system
+    skip if jruby9?
+
     rake_system_dir
     Dir.chdir @tempdir
 

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -43,6 +43,14 @@ class TestRakeTaskArguments < Rake::TestCase
     assert_equal ta.to_hash.inspect, ta.inspect
   end
 
+  def test_to_hash
+    ta = Rake::TaskArguments.new([:one], [1])
+    h = ta.to_hash
+    h[:one] = 0
+    assert_equal 1, ta.fetch(:one)
+    assert_equal 0,  h.fetch(:one)
+  end
+
   def test_enumerable_behavior
     ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])
     assert_equal [10, 20, 30], ta.map { |k, v| v * 10 }.sort


### PR DESCRIPTION
TaskArguments#to_hash is return @hash object.
The method should be return duplicated object like a "to_a".