### PR TITLE
skip tests with JRuby 9k. 

### DIFF
--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -284,6 +284,8 @@ class TestRakeApplication < Rake::TestCase
   end
 
   def test_load_rakefile_not_found
+    skip if jruby9?
+
     ARGV.clear
     Dir.chdir @tempdir
     ENV["RAKE_SYSTEM"] = "not_exist"

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -122,6 +122,8 @@ class TestRakeFunctional < Rake::TestCase
   end
 
   def test_implicit_system
+    skip if jruby9?
+
     rake_system_dir
     Dir.chdir @tempdir
 


### PR DESCRIPTION
ref. https://travis-ci.org/ruby/rake/jobs/163951069

It caused by `Dir.chdir` specification on JRuby