### PR TITLE
Represent a TaskArgument object such that it's not confused with a hash.

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -72,11 +72,15 @@ module Rake
     end
 
     def to_s # :nodoc:
-      @hash.inspect
+      inspect
     end
 
     def inspect # :nodoc:
-      to_s
+      inspection = @hash.map do |k,v|
+        "#{k.to_s}: #{v.to_s}"
+      end.join(", ")
+
+      "#<#{self.class} #{inspection}>"
     end
 
     # Returns true if +key+ is one of the arguments

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -39,8 +39,9 @@ class TestRakeTaskArguments < Rake::TestCase
 
   def test_to_s
     ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])
-    assert_equal ta.to_hash.inspect, ta.to_s
-    assert_equal ta.to_hash.inspect, ta.inspect
+    expectation = "#<Rake::TaskArguments a: 1, b: 2, c: 3>"
+    assert_equal expectation, ta.to_s
+    assert_equal expectation, ta.inspect
   end
 
   def test_to_hash


### PR DESCRIPTION
`ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])`

### Currently
`puts ta # {:a=>1, :b=>2, :c=>3}`

### Proposal
`puts ta # #<Rake::TaskArguments a: 1, b: 2, c: 3>`

### Why?
The current implementation leads one to believe they are working with a hash. This can lead to some confusion if you try doing something like `ta.a = 'one'` which will silently ignore the assignment.

In addition, I think `def_method` is preferable to `method_missing` to create accessors. That way `ta.a = 'one'` would generate a `NoMethodError`. Thoughts?

Shoutout to @eric-hu, with whom I discovered this issue.