### PR TITLE
Actions adore keyword arguments

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -247,14 +247,7 @@ module Rake
       end
       application.trace "** Execute #{name}" if application.options.trace
       application.enhance_with_matching_rule(name) if @actions.empty?
-      @actions.each do |act|
-        case act.arity
-        when 1
-          act.call(self)
-        else
-          act.call(self, args)
-        end
-      end
+      @actions.each { |act| act.call(self, args) }
     end
 
     # Is this task needed?

--- a/test/test_rake_task_with_arguments.rb
+++ b/test/test_rake_task_with_arguments.rb
@@ -85,13 +85,13 @@ class TestRakeTaskWithArguments < Rake::TestCase
     # A brutish trick to avoid parsing. Remove it once support for 1.9 and 2.0 is dropped
     # https://ci.appveyor.com/project/ruby/rake/build/1.0.301
     skip 'Keywords aren\'t a feature in this version' if RUBY_VERSION =~ /^1|^2\.0/
-    eval <<-RUBY, binding, __FILE__, __LINE__
+    eval <<-RUBY, binding, __FILE__, __LINE__+1
     notes = []
     t = task :t, [:reqr, :ovrd, :dflt] # required, overridden-optional, default-optional
     verify = lambda do |name, expecteds, actuals|
       notes << name
       assert_equal expecteds.length, actuals.length
-      expecteds.zip(actuals) { |e, a| assert_equal e, a, "(TEST #{name})" }
+      expecteds.zip(actuals) { |e, a| assert_equal e, a, "(TEST \#{name})" }
     end
 
     t.enhance { |dflt: 'd', **| verify.call :a, ['d'], [dflt] }

--- a/test/test_rake_task_with_arguments.rb
+++ b/test/test_rake_task_with_arguments.rb
@@ -82,6 +82,10 @@ class TestRakeTaskWithArguments < Rake::TestCase
 
 
   def test_actions_adore_keywords
+    # A brutish trick to avoid parsing. Remove it once support for 1.9 and 2.0 is dropped
+    # https://ci.appveyor.com/project/ruby/rake/build/1.0.301
+    skip 'Keywords aren\'t a feature in this version' if RUBY_VERSION =~ /^1|^2\.0/
+    eval <<-RUBY, binding, __FILE__, __LINE__
     notes = []
     t = task :t, [:reqr, :ovrd, :dflt] # required, overridden-optional, default-optional
     verify = lambda do |name, expecteds, actuals|
@@ -103,6 +107,7 @@ class TestRakeTaskWithArguments < Rake::TestCase
 
     t.invoke('r', 'o')
     assert_equal [*:a..:h], notes
+    RUBY
   end
 
   def test_arguments_are_passed_to_block


### PR DESCRIPTION
Consider this task:

```ruby
task :t, [:arg] do |task, arg: 'default_value'|
  emotion = "\e[32m^_^\e[0m"
  emotion = "\e[31mt.t\e[0m" if ARGV[0] =~ /t\[(.*)\]$/ && $1 != arg
  puts "task #{task.name.inspect} got #{arg.inspect} #{emotion}"
end
```

Run this on your machine right now and you'll see the task is in tears. But this commit turns tearful eyes into smiling ones, observe:

```sh
$ rake t
task "t" got "default_value" ^_^
$ rake t[custom_value]
task "t" got "default_value" t.t

$ ruby -Ilib exe/rake t
task "t" got "default_value" ^_^
$ ruby -Ilib exe/rake t[custom_value]
task "t" got "custom_value" ^_^
```

It accomplishes this by always invoking the action in the same way. [Previously](https://github.com/ruby/rake/blob/59856100815b841624269f817c815f54921bf321/lib/rake/task.rb#L251-L256), Rake invoke the action with different argument structures based the arity.

```ruby
case act.arity
when 1
  act.call(self)
else
  act.call(self, args)
end
```

I assume it's expecting one of these:

```ruby
proc { |task| }.arity           # => 1
proc { |task, options| }.arity  # => 2
```

However this leads numerous task signatures to be invoked incorrectly. Eg, consider the case of our tearful task above, here is why it cries.

```ruby
proc { |task, arg: 'default_value'| }.arity # => 1
```

The solution is nice and easy: always invoke the block the same way.

Why was this ever a thing at all, then? Looks like it was added in 2007 about a month after Ruby 1.8.6 was released. https://github.com/ruby/rake/commit/925fbb80e890029ac9310bc60270890699efc073 Probably something was just different back then, eg the ([difference](https://github.com/ruby/ruby/blob/9b383bd/eval.c#L8356-L8415)) between lambdas and procs was whether you did `prc.call` or `prc.yield`