### PR TITLE
Rake::TaskArguments#key? alias of #has_key?

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -87,6 +87,7 @@ module Rake
     def has_key?(key)
       @hash.has_key?(key)
     end
+    alias key? has_key?
 
     def fetch(*args, &block)
       @hash.fetch(*args, &block)

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -27,7 +27,9 @@ class TestRakeTaskArguments < Rake::TestCase
   def test_has_key
     ta = Rake::TaskArguments.new([:a], [:one])
     assert(ta.has_key?(:a))
+    assert(ta.key?(:a))
     refute(ta.has_key?(:b))
+    refute(ta.key?(:b))
   end
 
   def test_fetch


### PR DESCRIPTION
This PR adds `Rake::TaskArguments#key?(key)` as an alias of `has_key?(key)`.

---

`Rake::TaskArguments` exposes a Hash-like interface including `#has_key?(key)`, but is missing `#key?(key)`. Making this worse, the `method_missing` behaviour means `args.key?(:foo)` does not raise NoMethodError, instead treating it like `args[:key?]` and generally returning `nil`.

The commonly referenced [ruby-style-guide](https://github.com/bbatsov/ruby-style-guide#hash-key) says:

> Use `Hash#key?` instead of `Hash#has_key?` … As noted [here](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/43765) by Matz, the longer forms are considered deprecated.

which links to matz saying:

> "has_key" has already been deprecated by "key?"

[RuboCop](https://github.com/bbatsov/rubocop)'s `Style/PreferredHashMethods` rule complains about using `has_key?`:

```
lib/tasks/feed_consumer.rake:11:60: C: Use Hash#key? instead of Hash#has_key?.
    raise("task requires `interval` argument") unless args.has_key?(:interval)
                                                           ^^^^^^^^
```

However accepting its solution of using `#key?` causes silent failure via `method_missing` as described above.