### PR TITLE
change test in test_rake_task

### DIFF
--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -140,13 +140,9 @@ class TestRakeTask < Rake::TestCase
     end
 
     task(:foo).clear_comments
-
-    desc "a slightly different foo"
-    task :foo
-
-    assert_equal "a slightly different foo", task(:foo).comment
-    assert_equal ["x"], task(:foo).prerequisites
-    assert_equal 1, task(:foo).actions.size
+    
+    assert_nil task(:foo).comment
+    assert_empty task.prerequisites
   end
 
   def test_clear_args


### PR DESCRIPTION
Looking at this test, I felt like there wasn't a need to add a new description after clearing the original one. As the name of the test goes, just clearing the original comment, and testing that should be fine. Similar to `test_clear_args`, right after it.
If there needs to be a test for clearing and then adding another description, maybe writing another separate test would make things easier to allocate mentally.

Very small so I apologize! :octocat: