### PR TITLE
task_arguments.rb: delete unused *args

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -62,7 +62,7 @@ module Rake
     end
 
     # Returns the value of the given argument via method_missing
-    def method_missing(sym, *args)
+    def method_missing(sym)
       lookup(sym.to_sym)
     end
 


### PR DESCRIPTION
`*args` is not used in this method, so I deleted it.