### PR TITLE
When pattern is nil, enhance_with_matching_rule will not fail

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -126,7 +126,7 @@ module Rake
       fail Rake::RuleRecursionOverflowError,
         "Rule Recursion Too Deep" if level >= 16
       @rules.each do |pattern, args, extensions, block|
-        if pattern.match(task_name)
+        if pattern && pattern.match(task_name)
           task = attempt_rule(task_name, args, extensions, block, level)
           return task if task
         end


### PR DESCRIPTION
This fixes the

    NoMethodError: undefined method `match' for nil:NilClass

error with gettext/gettext_i18n_rails.

https://github.com/ManageIQ/manageiq/issues/4774