### PR TITLE
FileTask#out_of_date? calls depended FileTask#out_of_date? for execution

### DIFF
--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -29,7 +29,14 @@ module Rake
 
     # Are there any prerequisites with a later time than the given time stamp?
     def out_of_date?(stamp)
-      @prerequisites.any? { |n| application[n, @scope].timestamp > stamp }
+      @prerequisites.any? { |p|
+        ptask = application[p, @scope]
+        if ptask.instance_of?(Rake::FileTask)
+          ptask.timestamp > stamp || ptask.needed?
+        else
+          ptask.timestamp > stamp
+        end
+      }
     end
 
     # ----------------------------------------------------------------

--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -29,12 +29,12 @@ module Rake
 
     # Are there any prerequisites with a later time than the given time stamp?
     def out_of_date?(stamp)
-      @prerequisites.any? { |p|
-        ptask = application[p, @scope]
-        if ptask.instance_of?(Rake::FileTask)
-          ptask.timestamp > stamp || ptask.needed?
+      @prerequisites.any? { |prereq|
+        prereq_task = application[prereq, @scope]
+        if prereq_task.instance_of?(Rake::FileTask)
+          prereq_task.timestamp > stamp || prereq_task.needed?
         else
-          ptask.timestamp > stamp
+          prereq_task.timestamp > stamp
         end
       }
     end

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -77,6 +77,24 @@ end
     DEFAULT
   end
 
+  def rakefile_file_chains
+    rakefile <<-RAKEFILE
+file "fileA" do |t|
+  sh "echo contentA >\#{t.name}"
+end
+
+file "fileB" => "fileA" do |t|
+  sh "(cat fileA; echo transformationB) >\#{t.name}"
+end
+
+file "fileC" => "fileB" do |t|
+  sh "(cat fileB; echo transformationC) >\#{t.name}"
+end
+
+task default: "fileC"
+    RAKEFILE
+  end
+
   def rakefile_comments
     rakefile <<-COMMENTS
 # comment for t1

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -309,6 +309,7 @@ class TestRakeFunctional < Rake::TestCase
     rake "-n"
     assert_equal(%w{fileA fileB fileC default}, dryrun_tasks)
     rake
+    sleep 1 # for stride seconds surely for timestamp
     FileUtils.touch("fileA")
     rake "-n"
     assert_equal(%w{fileB fileC default}, dryrun_tasks)

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -295,6 +295,25 @@ class TestRakeFunctional < Rake::TestCase
            "'play.app' file should exist"
   end
 
+  def dryrun_tasks
+    @err.split("\n").select { |line|
+      line.match(/^\*\* Execute/)
+    }.map { |line|
+      line.gsub(/^\*\* Execute \(dry run\) /, "")
+    }
+  end
+
+  def test_update_midway_through_chaining_to_file_task
+    rakefile_file_chains
+
+    rake "-n"
+    assert_equal(%w{fileA fileB fileC default}, dryrun_tasks)
+    rake
+    FileUtils.touch("fileA")
+    rake "-n"
+    assert_equal(%w{fileB fileC default}, dryrun_tasks)
+  end
+
   def test_file_creation_task
     rakefile_file_creation
 

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -309,7 +309,7 @@ class TestRakeFunctional < Rake::TestCase
     rake "-n"
     assert_equal(%w{fileA fileB fileC default}, dryrun_tasks)
     rake
-    sleep 1 # for stride seconds surely for timestamp
+    sleep 1 # Ensure the timestamp is on a new second
     FileUtils.touch("fileA")
     rake "-n"
     assert_equal(%w{fileB fileC default}, dryrun_tasks)


### PR DESCRIPTION
This fixes #92 what says below:

> The problem seems to stem from the fact that the internal function `out_of_date?` (in `file_task.rb`) does not take into account when a file should have updated its timestamp (but didn't, because this is a dry-run).

I think so. In this Pull Request, `FileTask#out_of_date?` calls dependency `FileTask`'s `#out_of_date?` via `FileTask#needed?`.