### PR TITLE
Travis: add 2.4.0 to matrix, update patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
   - ruby-head
-  - jruby-1.7.20
+  - jruby-1.7.26
   - jruby-9.1.6.0
   - jruby-head
 before_install:


### PR DESCRIPTION
This PR adds 2.4.0 as a test target in Travis.

It also takes the patch versions of other rubies from the `ruby-install --latest` output and updates them.