### PR TITLE
The "raise" with no arguments raises the exception in $!, nested case too

### DIFF
--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -80,11 +80,11 @@ class TestRakeApplication < Rake::TestCase
     begin
       begin
         raise "cause a"
-      rescue => a
+      rescue
         begin
           raise "cause b"
         rescue
-          raise a
+          raise
         end
       end
     rescue => ex


### PR DESCRIPTION
Ruby 2.4 and later, `raise`'s behavior has been changed. Nested `raise` with an argument raises only the argument, it doesn't have outer exception. So I removed the argument. The `raise` with no arguments raises what contains nested exceptions.

This fixes a failure of `TestRakeApplication#test_display_exception_details_cause_loop` that @hsbt refers at https://github.com/ruby/rake/pull/184. This [passed all Ruby versions in Travis CI](https://travis-ci.org/aycabta/rake/builds/187525488).

...And this will fix Travis CI failure of https://github.com/ruby/rake/pull/183.