### PR TITLE
Remove an extra assertion

### DIFF
--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -97,7 +97,6 @@ class TestRakeApplication < Rake::TestCase
     assert_empty out
 
     assert_match "cause a", err
-    assert_match "cause b", err
   end
 
   def test_display_tasks


### PR DESCRIPTION
As the result of https://bugs.ruby-lang.org/issues/13043, now `Exception#cause` should not have a loop.

In the example https://github.com/jimweirich/rake/issues/272, the code doesn't seem to intend the loop itself but just re-raising the first exception instead of the next exception.  Therefore I consider the last assertion superfluous.