### PR TITLE
Make LoadError from running tests more obvious

### DIFF
--- a/lib/rake/rake_test_loader.rb
+++ b/lib/rake/rake_test_loader.rb
@@ -2,19 +2,23 @@ require "rake"
 
 # Load the test files from the command line.
 argv = ARGV.select do |argument|
-  case argument
-  when /^-/ then
-    argument
-  when /\*/ then
-    FileList[argument].to_a.each do |file|
-      require File.expand_path file
+  begin
+    case argument
+    when /^-/ then
+      argument
+    when /\*/ then
+      FileList[argument].to_a.each do |file|
+        require File.expand_path file
+      end
+
+      false
+    else
+      require File.expand_path argument
+
+      false
     end
-
-    false
-  else
-    require File.expand_path argument
-
-    false
+  rescue LoadError => e
+    abort "\n#{e.message}\n\n"
   end
 end
 

--- a/lib/rake/rake_test_loader.rb
+++ b/lib/rake/rake_test_loader.rb
@@ -18,7 +18,7 @@ argv = ARGV.select do |argument|
       false
     end
   rescue LoadError => e
-    abort "\n#{e.message}\n\n"
+    abort "\nFile does not exist: #{e.path}\n\n"
   end
 end
 

--- a/test/test_rake_rake_test_loader.rb
+++ b/test/test_rake_rake_test_loader.rb
@@ -26,7 +26,7 @@ class TestRakeRakeTestLoader < Rake::TestCase
   def test_load_error
     expected = <<-EXPECTED
 
-cannot load such file -- #{File.join @tempdir, 'no_such_test_file.rb'}
+File does not exist: #{File.join @tempdir, 'no_such_test_file.rb'}
 
     EXPECTED
 

--- a/test/test_rake_rake_test_loader.rb
+++ b/test/test_rake_rake_test_loader.rb
@@ -2,6 +2,12 @@ require File.expand_path("../helper", __FILE__)
 
 class TestRakeRakeTestLoader < Rake::TestCase
 
+  def setup
+    super
+
+    @loader = File.join @rake_lib, 'rake/rake_test_loader.rb'
+  end
+
   def test_pattern
     orig_loaded_features = $:.dup
     FileUtils.touch "foo.rb"
@@ -10,11 +16,26 @@ class TestRakeRakeTestLoader < Rake::TestCase
 
     ARGV.replace %w[foo.rb test_*.rb -v]
 
-    load File.join(@rake_lib, "rake/rake_test_loader.rb")
+    load @loader
 
     assert_equal %w[-v], ARGV
   ensure
     $:.replace orig_loaded_features
   end
 
+  def test_load_error
+    expected = <<-EXPECTED
+
+cannot load such file -- #{File.join @tempdir, 'no_such_test_file.rb'}
+
+    EXPECTED
+
+    assert_output nil, expected do
+      ARGV.replace %w[no_such_test_file.rb]
+
+      assert_raises SystemExit do
+        load @loader
+      end
+    end
+  end
 end

--- a/test/test_rake_rake_test_loader.rb
+++ b/test/test_rake_rake_test_loader.rb
@@ -24,18 +24,23 @@ class TestRakeRakeTestLoader < Rake::TestCase
   end
 
   def test_load_error
-    expected = <<-EXPECTED
-
-File does not exist: #{File.join @tempdir, 'no_such_test_file.rb'}
-
-    EXPECTED
-
-    assert_output nil, expected do
+    out, err = capture_io do
       ARGV.replace %w[no_such_test_file.rb]
 
       assert_raises SystemExit do
         load @loader
       end
     end
+
+    assert_empty out
+
+    no_such_path = File.join @tempdir, 'no_such_test_file'
+
+    expected =
+      /\A\n
+       File\ does\ not\ exist:\ #{no_such_path}(\.rb)? # JRuby is different
+       \n\n\Z/x
+
+    assert_match expected, err
   end
 end


### PR DESCRIPTION
When you attempt to run tests on a nonexistent file the error can be buried (see #194).  This change adds some whitespace and removes the backtrace to make the error more visible.

```
$ rake test TEST=no_such_file
/usr/local/bin/ruby -w -I"lib:test" -I"/Users/erichodel/Work/git/rake/lib" "/Users/erichodel/Work/git/rake/lib/rake/rake_test_loader.rb" "no_such_file" 

cannot load such file -- /Users/erichodel/Work/git/rake/no_such_file

rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" -I"/Users/erichodel/Work/git/rake/lib" "/Users/erichodel/Work/git/rake/lib/rake/rake_test_loader.rb" "no_such_file" ]

Tasks: TOP => test
(See full trace by running task with --trace)
```