### PR TITLE
Update to latest versions of Ruby 2.2, 2.3 and JRuby 9k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: false
 rvm:
   - 2.0.0
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
+  - 2.2.7
+  - 2.3.4
   - 2.4.1
   - ruby-head
-  - jruby-9.1.6.0
+  - jruby-9.1.9.0
   - jruby-head
 before_install:
   - gem install bundler --no-document -v '~> 1.13.3'


### PR DESCRIPTION
[JRuby 9.1.10.0 has been released](http://jruby.org/2017/05/25/jruby-9-1-10-0.html), but there is not in list of ["Travis CI: Precompiled Ruby Versions"](http://rubies.travis-ci.org/). So I added `jruby-9.1.9.0` what is in the list now.