### PR TITLE
Make rake easier to use as a library

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -74,19 +74,19 @@ module Rake
     # If you wish to build a custom rake command, you should call
     # +init+ on your application.  Then define any tasks.  Finally,
     # call +top_level+ to run your top level tasks.
-    def run
+    def run(argv = ARGV)
       standard_exception_handling do
-        init
+        init 'rake', argv
         load_rakefile
         top_level
       end
     end
 
     # Initialize the command line parameters and app name.
-    def init(app_name="rake")
+    def init(app_name="rake", argv = ARGV)
       standard_exception_handling do
         @name = app_name
-        args = handle_options
+        args = handle_options argv
         collect_command_line_tasks(args)
       end
     end
@@ -618,7 +618,7 @@ module Rake
     # Read and handle the command line options.  Returns the command line
     # arguments that we didn't understand, which should (in theory) be just
     # task names and env vars.
-    def handle_options # :nodoc:
+    def handle_options(argv) # :nodoc:
       set_default_options
 
       OptionParser.new do |opts|
@@ -633,7 +633,7 @@ module Rake
 
         standard_rake_options.each { |args| opts.on(*args) }
         opts.environment("RAKEOPT")
-      end.parse(ARGV)
+      end.parse(argv)
     end
 
     # Similar to the regular Ruby +require+ command, but will check

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -62,6 +62,8 @@ module Rake
       add_loader("rake", DefaultLoader.new)
       @tty_output = STDOUT.tty?
       @terminal_columns = ENV["RAKE_COLUMNS"].to_i
+
+      set_default_options
     end
 
     # Run the Rake application.  The run method performs the following

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -619,8 +619,7 @@ module Rake
     # arguments that we didn't understand, which should (in theory) be just
     # task names and env vars.
     def handle_options # :nodoc:
-      options.rakelib = ["rakelib"]
-      options.trace_output = $stderr
+      set_default_options
 
       OptionParser.new do |opts|
         opts.banner = "#{Rake.application.name} [-f rakefile] {options} targets..."
@@ -780,6 +779,29 @@ module Rake
       re = /#{re.source}/i if windows?
 
       backtrace.find { |str| str =~ re } || ""
+    end
+
+    def set_default_options
+      options.always_multitask           = false
+      options.backtrace                  = false
+      options.build_all                  = false
+      options.dryrun                     = false
+      options.ignore_deprecate           = false
+      options.ignore_system              = false
+      options.job_stats                  = false
+      options.load_system                = false
+      options.nosearch                   = false
+      options.rakelib                    = %w[rakelib]
+      options.show_all_tasks             = false
+      options.show_prereqs               = false
+      options.show_task_pattern          = nil
+      options.show_tasks                 = nil
+      options.silent                     = false
+      options.suppress_backtrace_pattern = nil
+      options.thread_pool_size           = Rake.suggested_thread_count
+      options.trace                      = false
+      options.trace_output               = $stderr
+      options.trace_rules                = false
     end
 
   end

--- a/lib/rake/rake_module.rb
+++ b/lib/rake/rake_module.rb
@@ -34,6 +34,36 @@ module Rake
       application.options.rakelib ||= []
       application.options.rakelib.concat(files)
     end
+
+    # Make +block_application+ the default rake application inside a block so
+    # you can load rakefiles into a different application.
+    #
+    # This is useful when you want to run rake tasks inside a library without
+    # running rake in a sub-shell.
+    #
+    # Example:
+    #
+    #   Dir.chdir 'other/directory'
+    #
+    #   other_rake = Rake.with_application do |rake|
+    #     rake.set_default_options
+    #
+    #     rake.load_rakefile
+    #   end
+    #
+    #   puts other_rake.tasks
+
+    def with_application(block_application = Rake::Application.new)
+      orig_application = Rake.application
+
+      Rake.application = block_application
+
+      yield block_application
+
+      block_application
+    ensure
+      Rake.application = orig_application
+    end
   end
 
 end

--- a/lib/rake/rake_module.rb
+++ b/lib/rake/rake_module.rb
@@ -46,8 +46,6 @@ module Rake
     #   Dir.chdir 'other/directory'
     #
     #   other_rake = Rake.with_application do |rake|
-    #     rake.set_default_options
-    #
     #     rake.load_rakefile
     #   end
     #

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -10,6 +10,36 @@ class TestRakeApplication < Rake::TestCase
     @app.options.rakelib = []
   end
 
+  def test_class_with_application
+    orig_app = Rake.application
+
+    return_app = Rake.with_application do |yield_app|
+      refute_equal orig_app, yield_app, 'new application must be yielded'
+
+      assert_equal yield_app, Rake.application,
+                   'new application must be default in block'
+    end
+
+    refute_equal orig_app, return_app, 'new application not returned'
+    assert_equal orig_app, Rake.application, 'original application not default'
+  end
+
+  def test_class_with_application_user_defined
+    orig_app = Rake.application
+
+    user_app = Rake::Application.new
+
+    return_app = Rake.with_application user_app do |yield_app|
+      assert_equal user_app, yield_app, 'user application must be yielded'
+
+      assert_equal user_app, Rake.application,
+                   'user application must be default in block'
+    end
+
+    assert_equal user_app, return_app, 'user application not returned'
+    assert_equal orig_app, Rake.application, 'original application not default'
+  end
+
   def test_display_exception_details
     obj = Object.new
     obj.instance_eval("def #{__method__}; raise 'test'; end", "ruby")

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -49,6 +49,8 @@ class TestRakeApplication < Rake::TestCase
     end
 
     out, err = capture_io do
+      @app.set_default_options # reset trace output IO
+
       @app.display_error_message ex
     end
 
@@ -65,6 +67,8 @@ class TestRakeApplication < Rake::TestCase
     end
 
     out, err = capture_io do
+      @app.set_default_options # reset trace output IO
+
       @app.display_error_message ex
     end
 
@@ -86,6 +90,8 @@ class TestRakeApplication < Rake::TestCase
     end
 
     out, err = capture_io do
+      @app.set_default_options # reset trace output IO
+
       @app.display_error_message ex
     end
 
@@ -472,6 +478,7 @@ class TestRakeApplication < Rake::TestCase
   def test_bad_run_with_trace
     @app.intern(Rake::Task, "default").enhance { fail }
     _, err = capture_io {
+      @app.set_default_options
       assert_raises(SystemExit) { @app.run %w[-f -s -t] }
     }
     refute_match(/see full trace/i, err)
@@ -563,6 +570,8 @@ class TestRakeApplication < Rake::TestCase
 
   def test_standard_exception_handling_other
     out, err = capture_io do
+      @app.set_default_options # reset trace output IO
+
       e = assert_raises SystemExit do
         @app.standard_exception_handling do
           raise "blah"

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -9,7 +9,6 @@ class TestRakeApplicationOptions < Rake::TestCase
     super
 
     @testkey = ENV["TESTKEY"]
-    clear_argv
     Rake::FileUtilsExt.verbose_flag = false
     Rake::FileUtilsExt.nowrite_flag = false
     TESTING_REQUIRE.clear
@@ -17,15 +16,10 @@ class TestRakeApplicationOptions < Rake::TestCase
 
   def teardown
     ENV["TESTKEY"] = @testkey
-    clear_argv
     Rake::FileUtilsExt.verbose_flag = false
     Rake::FileUtilsExt.nowrite_flag = false
 
     super
-  end
-
-  def clear_argv
-    ARGV.pop until ARGV.empty?
   end
 
   def test_default_options

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -30,19 +30,19 @@ class TestRakeApplicationOptions < Rake::TestCase
 
   def test_default_options
     opts = command_line
-    assert_nil opts.backtrace
-    assert_nil opts.dryrun
-    assert_nil opts.ignore_system
-    assert_nil opts.load_system
-    assert_nil opts.always_multitask
-    assert_nil opts.nosearch
+    assert_equal false, opts.backtrace
+    assert_equal false, opts.dryrun
+    assert_equal false, opts.ignore_system
+    assert_equal false, opts.load_system
+    assert_equal false, opts.always_multitask
+    assert_equal false, opts.nosearch
     assert_equal ["rakelib"], opts.rakelib
-    assert_nil opts.show_prereqs
+    assert_equal false, opts.show_prereqs
     assert_nil opts.show_task_pattern
     assert_nil opts.show_tasks
-    assert_nil opts.silent
-    assert_nil opts.trace
-    assert_nil opts.thread_pool_size
+    assert_equal false, opts.silent
+    assert_equal false, opts.trace
+    assert_equal Rake.suggested_thread_count, opts.thread_pool_size
     assert_equal ["rakelib"], opts.rakelib
     assert ! Rake::FileUtilsExt.verbose_flag
     assert ! Rake::FileUtilsExt.nowrite_flag
@@ -115,7 +115,7 @@ class TestRakeApplicationOptions < Rake::TestCase
 
   def test_jobs
     flags([]) do |opts|
-      assert_nil opts.thread_pool_size
+      assert_equal Rake.suggested_thread_count, opts.thread_pool_size
     end
     flags(["--jobs", "0"], ["-j", "0"]) do |opts|
       assert_equal 0, opts.thread_pool_size
@@ -329,12 +329,12 @@ class TestRakeApplicationOptions < Rake::TestCase
     flags("--tasks", "-T") do |opts|
       assert_equal :tasks, opts.show_tasks
       assert_equal(//.to_s, opts.show_task_pattern.to_s)
-      assert_nil opts.show_all_tasks
+      assert_equal false, opts.show_all_tasks
     end
     flags(["--tasks", "xyz"], ["-Txyz"]) do |opts|
       assert_equal :tasks, opts.show_tasks
       assert_equal(/xyz/.to_s, opts.show_task_pattern.to_s)
-      assert_nil opts.show_all_tasks
+      assert_equal false, opts.show_all_tasks
     end
     flags(["--tasks", "xyz", "--comments"]) do |opts|
       assert_equal :tasks, opts.show_tasks

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -445,8 +445,6 @@ class TestRakeApplicationOptions < Rake::TestCase
 
   def flags(*sets)
     sets.each do |set|
-      ARGV.clear
-
       @exit = catch(:system_exit) { command_line(*set) }
 
       yield(@app.options) if block_given?
@@ -454,13 +452,12 @@ class TestRakeApplicationOptions < Rake::TestCase
   end
 
   def command_line(*options)
-    options.each do |opt| ARGV << opt end
     @app = Rake::Application.new
     def @app.exit(*args)
       throw :system_exit, :exit
     end
     @app.instance_eval do
-      args = handle_options
+      args = handle_options options
       collect_command_line_tasks(args)
     end
     @tasks = @app.top_level_tasks

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -62,10 +62,14 @@ class TestRakeTask < Rake::TestCase
   end
 
   def test_dry_run_prevents_actions
-    Rake.application.options.dryrun = true
     runlist = []
     t1 = task(:t1) { |t| runlist << t.name; 3321 }
-    _, err = capture_io { t1.invoke }
+    _, err = capture_io {
+      Rake.application.set_default_options # reset trace output IO
+      Rake.application.options.dryrun = true
+
+      t1.invoke
+    }
     assert_match(/execute .*t1/i, err)
     assert_match(/dry run/i, err)
     refute_match(/invoke/i, err)
@@ -75,9 +79,11 @@ class TestRakeTask < Rake::TestCase
   end
 
   def test_tasks_can_be_traced
-    Rake.application.options.trace = true
     t1 = task(:t1)
     _, err = capture_io {
+      Rake.application.set_default_options # reset trace output IO
+      Rake.application.options.trace = true
+
       t1.invoke
     }
     assert_match(/invoke t1/i, err)

--- a/test/test_rake_task_argument_parsing.rb
+++ b/test/test_rake_task_argument_parsing.rb
@@ -96,16 +96,14 @@ class TestRakeTaskArgumentParsing < Rake::TestCase
   end
 
   def test_no_rakeopt
-    ARGV << "--trace"
     app = Rake::Application.new
-    app.init
+    app.init %w[--trace]
     assert !app.options.silent
   end
 
   def test_rakeopt_with_blank_options
-    ARGV << "--trace"
     app = Rake::Application.new
-    app.init
+    app.init %w[--trace]
     assert !app.options.silent
   end
 

--- a/test/test_rake_win32.rb
+++ b/test/test_rake_win32.rb
@@ -65,7 +65,11 @@ class TestRakeWin32 < Rake::TestCase
     rake.options.trace = true
     rake.instance_variable_set(:@rakefile, "Rakefile")
 
-    _, err = capture_io { rake.display_error_message(ex) }
+    _, err = capture_io {
+      rake.set_default_options # reset trace output IO
+
+      rake.display_error_message(ex)
+    }
 
     assert_match(/rakefile/, err)
   end


### PR DESCRIPTION
I want to be able to load a set of rake tasks from within another application.  Doing this presently is difficult, and looks something like this:

```ruby
Dir.chdir 'other/dir'

rake = Rake::Application.new
Rake.application = rake

rake.options.trace = true
rake.options.backtrace = true
rake.options.rakelib = %w[rakelib]

rake.load_rakefile

puts rake.tasks
```

Figuring out which options you need to set is hard (and not documented), figuring out you need to set `Rake.application` is not documented, and the process of getting your Rakefile loaded is not documented.

This PR replaces the above with a much simpler option:

```ruby
Dir.chdir 'other/dir'

rake = Rake.with_application do |rake|
  rake.load_rakefile
end

puts rake.tasks
```

Figuring out which options is now hidden from the user.

There are a few other API niceties in here like being able to create a new Rake application using a separate set of command line arguments from `ARGV` (so you don't have to overwrite `ARGV`).

Some tests that use `capture_io` got a little more confusing because the output IO was set to real-`$stderr` before `capture_io` changed `$stderr` to a StringIO.