### PR TITLE
gemspec: Exclude various YAML configuration files

### DIFF
--- a/rake.gemspec
+++ b/rake.gemspec
@@ -24,7 +24,8 @@ Rake has the following features:
   s.homepage = "https://github.com/ruby/rake".freeze
   s.licenses = ["MIT".freeze]
 
-  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) } -
+            %w[.rubocop.yml .travis.yml appveyor.yml]
   s.bindir = "exe"
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib".freeze]


### PR DESCRIPTION
This PR makes the gemspec exclude 3 configuration files from the repository's root directory.

The problem that this change solves for me is that a Rake-task-based RuboCop
configuration-file finding method can run into these RuboCop rules, when they
are in a searched filesystem path.

(Another issue: The rules for this project currently present warnings when run with RuboCop 0.49.1.)

The warnings:

<details>

```
/Users/olle/opensource/rake/.rubocop.yml: Style/LineLength has the wrong namespace - should be Metrics
/Users/olle/opensource/rake/.rubocop.yml: Style/IndentationWidth has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/Tab has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/EmptyLines has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/TrailingBlankLines has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/TrailingWhitespace has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/SpaceBeforeBlockBraces has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/SpaceInsideBlockBraces has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/SpaceInsideHashLiteralBraces has the wrong namespace - should be Layout
/Users/olle/opensource/rake/.rubocop.yml: Style/CaseIndentation has the wrong namespace - should be Layout
Error: obsolete parameter AlignWith (for Lint/EndAlignment) found in /Users/olle/opensource/rake/.rubocop.yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
```

</details>