### PR TITLE
Added did you mean to rake

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -56,7 +56,21 @@ module Rake
       self.lookup(task_name, scopes) or
         enhance_with_matching_rule(task_name) or
         synthesize_file_task(task_name) or
-        fail "Don't know how to build task '#{task_name}' (see --tasks)"
+        fail generate_message_for_undefined_task(task_name)
+    end
+
+    def generate_message_for_undefined_task(task_name)
+      message = "Don't know how to build task '#{task_name}' (see --tasks)"
+
+      suggestion_message = \
+        if defined?(::DidYouMean::SpellChecker) && defined?(::DidYouMean::Formatter)
+          suggestions = ::DidYouMean::SpellChecker.new(dictionary: @tasks.keys).correct(task_name.to_s)
+          ::DidYouMean::Formatter.new(suggestions).to_s
+        else
+          ""
+        end
+
+      message + suggestion_message
     end
 
     def synthesize_file_task(task_name) # :nodoc:

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -453,4 +453,15 @@ class TestRakeTask < Rake::TestCase
     t = task t: ["preqA", "preqB"]
     assert_equal "preqA", t.source
   end
+
+  def test_suggests_valid_rake_task_names
+    task :test
+    error = assert_raises(RuntimeError) { Task[:testt] }
+
+    assert_match /Don\'t know how to build task \'testt\'/, error.message
+
+    if defined?(::DidYouMean::SpellChecker) && defined?(::DidYouMean::Formatter)
+      assert_match /Did you mean\?  test/, error.message
+    end
+  end
 end


### PR DESCRIPTION
This is a follow up of an [older PR](https://github.com/ruby/rake/pull/29/files) that added a better message for invalid rake task names. The proposed change uses did you mean in order make a rake task suggestion in addition to the default error message.