### PR TITLE
fix quadratic performance in FileTask#out_of_date?

### DIFF
--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -30,10 +30,10 @@ module Rake
 
     # Are there any prerequisites with a later time than the given time stamp?
     def out_of_date?(stamp)
-      @prerequisites.any? { |prereq|
+      all_prerequisite_tasks.any? { |prereq|
         prereq_task = application[prereq, @scope]
         if prereq_task.instance_of?(Rake::FileTask)
-          prereq_task.timestamp > stamp || prereq_task.needed?
+          prereq_task.timestamp > stamp || @application.options.build_all
         else
           prereq_task.timestamp > stamp
         end


### PR DESCRIPTION
FileTask#out_of_date? has been changed in 462e403a to call #needed?
which calls #out_of_date? recursively. In some cases, where the
graph of dependencies is fairly dense, this leads to quadratic
performance when it was linear before.

Use #all_prerequisite_tasks to avoid the problem. This also saves
a File.exist? test as #timestamp already takes it into account.