### PR TITLE
fixed warnings

### DIFF
--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -464,10 +464,10 @@ class TestRakeTask < Rake::TestCase
     task :test
     error = assert_raises(RuntimeError) { Task[:testt] }
 
-    assert_match /Don\'t know how to build task \'testt\'/, error.message
+    assert_match(/Don\'t know how to build task \'testt\'/, error.message)
 
     if defined?(::DidYouMean::SpellChecker) && defined?(::DidYouMean::Formatter)
-      assert_match /Did you mean\?  test/, error.message
+      assert_match(/Did you mean\?  test/, error.message)
     end
   end
 end


### PR DESCRIPTION
```
test/test_rake_task.rb:467: warning: ambiguous first argument; put parentheses or a space even after `/' operator
test/test_rake_task.rb:470: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```