### PR TITLE
Account for a file that match 2 or more patterns.

### DIFF
--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -318,14 +318,14 @@ module Rake
     # Return a new file list that only contains file names from the current
     # file list that exist on the file system.
     def existing
-      select { |fn| File.exist?(fn) }
+      select { |fn| File.exist?(fn) }.uniq
     end
 
     # Modify the current file list so that it contains only file name that
     # exist on the file system.
     def existing!
       resolve
-      @items = @items.select { |fn| File.exist?(fn) }
+      @items = @items.select { |fn| File.exist?(fn) }.uniq
       self
     end
 

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -415,13 +415,13 @@ class TestRakeFileList < Rake::TestCase
   end
 
   def test_existing
-    fl = FileList["abc.c", "notthere.c"]
+    fl = FileList["*c.c", "notthere.c", "a*.c"]
     assert_equal ["abc.c"], fl.existing
     assert fl.existing.is_a?(FileList)
   end
 
   def test_existing!
-    fl = FileList["abc.c", "notthere.c"]
+    fl = FileList["*c.c", "notthere.c", "a*.c"]
     result = fl.existing!
     assert_equal ["abc.c"], fl
     assert_equal fl.object_id, result.object_id


### PR DESCRIPTION
I believe calling `existing` on a FileList should return a unique list because files in a directory are unique. This could also solve issue #30 and #225 if he calls each on the existing FileList.