### PR TITLE
Clarify output when printing nested exception traces

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -207,13 +207,22 @@ module Rake
     end
 
     def display_exception_details(ex) # :nodoc:
-      seen = Thread.current[:rake_display_exception_details_seen] ||= []
-      return if seen.include? ex
-      seen << ex
+      display_exception_details_seen << ex
 
       display_exception_message_details(ex)
       display_exception_backtrace(ex)
-      display_exception_details(ex.cause) if has_cause?(ex)
+      display_cause_details(ex.cause) if has_cause?(ex)
+    end
+
+    def display_cause_details(ex) # :nodoc:
+      return if display_exception_details_seen.include? ex
+
+      trace "\nCaused by:"
+      display_exception_details(ex)
+    end
+
+    def display_exception_details_seen # :nodoc:
+      Thread.current[:rake_display_exception_details_seen] ||= []
     end
 
     def has_cause?(ex) # :nodoc:

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -97,6 +97,7 @@ class TestRakeApplication < Rake::TestCase
 
     assert_empty out
 
+    assert_match "Caused by:", err
     assert_match "cause a", err
     assert_match "cause b", err
   end


### PR DESCRIPTION
Since v10.2.0, if an exception has a nested cause exception, [the cause is also displayed in the trace output](https://github.com/ruby/rake/commit/fbb22e7f570fc573ad1bff9d5905df1ab1cbd475).

For deeply-nested exceptions, this output can be quite lengthy - for example, Rails migrations nest DB errors twice over, resulting in an error message and backtrace repeated three times. With long backtraces, this output can be difficult to visually scan.

To break up the output and make it clearer what each individual backtrace relates to, this PR adds whitespace and a "Caused by:" label to each nested exception being displayed.

Given the following `Rakefile`:

```ruby
task :oops do
  begin
    raise StandardError, "oops"
  rescue => a
    begin
      raise ArgumentError, "didn't like that", cause: a
    rescue => b
      raise SyntaxError, "why not eh", cause: b
    end
  end
end
```

This changes the output from this in current `master`:

```
$ rake oops
rake aborted!
SyntaxError: why not eh
/Users/simon/dev/clones/rake/Rakefile:8:in `rescue in rescue in block in <top (required)>'
/Users/simon/dev/clones/rake/Rakefile:5:in `rescue in block in <top (required)>'
/Users/simon/dev/clones/rake/Rakefile:2:in `block in <top (required)>'
/Users/simon/.gem/ruby/2.4.2/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
ArgumentError: didn't like that
/Users/simon/dev/clones/rake/Rakefile:6:in `rescue in block in <top (required)>'
/Users/simon/dev/clones/rake/Rakefile:2:in `block in <top (required)>'
/Users/simon/.gem/ruby/2.4.2/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
StandardError: oops
/Users/simon/dev/clones/rake/Rakefile:3:in `block in <top (required)>'
/Users/simon/.gem/ruby/2.4.2/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => oops
(See full trace by running task with --trace)
```

To this:

```
$ rake oops
rake aborted!
SyntaxError: why not eh
/Users/simon/dev/clones/rake/Rakefile:8:in `rescue in rescue in block in <top (required)>'
/Users/simon/dev/clones/rake/Rakefile:5:in `rescue in block in <top (required)>'
/Users/simon/dev/clones/rake/Rakefile:2:in `block in <top (required)>'
/Users/simon/dev/clones/rake/exe/rake:27:in `<top (required)>'

Caused by:
ArgumentError: didn't like that
/Users/simon/dev/clones/rake/Rakefile:6:in `rescue in block in <top (required)>'
/Users/simon/dev/clones/rake/Rakefile:2:in `block in <top (required)>'
/Users/simon/dev/clones/rake/exe/rake:27:in `<top (required)>'

Caused by:
StandardError: oops
/Users/simon/dev/clones/rake/Rakefile:3:in `block in <top (required)>'
/Users/simon/dev/clones/rake/exe/rake:27:in `<top (required)>'
Tasks: TOP => oops
(See full trace by running task with --trace)
```

Is this a change you'd be interested in merging? If so, feedback on both the output and implementation would be very welcome, and I'd be happy to make any changes necessary.

Cheers,
Simon