### PR TITLE
update required_ruby_version to 2.0.0

### DIFF
--- a/rake.gemspec
+++ b/rake.gemspec
@@ -30,7 +30,7 @@ Rake has the following features:
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib".freeze]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3".freeze)
+  s.required_ruby_version = Gem::Requirement.new(">= 2.0.0".freeze)
   s.rubygems_version = "2.6.1".freeze
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.2".freeze)
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]


### PR DESCRIPTION
- as suggested by @hsbt in issue #230 on github
- problems with 1.9.3 have been reported, which is long EOL'd