### PR TITLE
make clear that scope is ignored purposely

### DIFF
--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -44,9 +44,9 @@ module Rake
     # Task class methods.
     #
     class << self
-      # Apply the scope to the task name according to the rules for this kind
-      # of task.  File based tasks ignore the scope when creating the name.
-      def scope_name(scope, task_name)
+      # This method signature is from Task.  FileTasks ignore the scope when
+      # creating the name.
+      def scope_name(_scope, task_name)
         Rake.from_pathname(task_name)
       end
     end


### PR DESCRIPTION
I'm not 100% certain on whether this change is desirable or self-evidently so.  But I definitely had to do a double-take when I looked at the method definition and saw that only the last argument was even considered.  The existing comments somewhat explain it.  I think the leading underscore on `_scope` makes the code more self-evident.

Note, this PR was resubmitted from a non-master branch of my fork.