### PR TITLE
Add a Rake.application.running? predicate

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -56,6 +56,7 @@ module Rake
       @loaders = {}
       @default_loader = Rake::DefaultLoader.new
       @original_dir = Dir.pwd
+      @running = false
       @top_level_tasks = []
       add_loader("rb", DefaultLoader.new)
       add_loader("rf", DefaultLoader.new)
@@ -77,11 +78,13 @@ module Rake
     # +init+ on your application.  Then define any tasks.  Finally,
     # call +top_level+ to run your top level tasks.
     def run(argv = ARGV)
+      @running = true
       standard_exception_handling do
         init "rake", argv
         load_rakefile
         top_level
       end
+      @running = false
     end
 
     # Initialize the command line parameters and app name.
@@ -149,6 +152,12 @@ module Rake
     # Return the thread pool used for multithreaded processing.
     def thread_pool             # :nodoc:
       @thread_pool ||= ThreadPool.new(options.thread_pool_size || Rake.suggested_thread_count-1)
+    end
+
+    # Is true, if the Rake application is currently running
+    # (in other words, that the +rake+ command line script was invoked)
+    def running?
+      @running
     end
 
     # internal ----------------------------------------------------------------

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -634,4 +634,22 @@ class TestRakeApplication < Rake::TestCase
     loader
   end
 
+  def test_running
+    was_running = false
+
+    @app.instance_eval do
+      app = self
+      intern(Rake::Task, "default").enhance do
+        was_running = app.running?
+      end
+    end
+
+    rakefile_default
+
+    assert !@app.running?
+    @app.run %w[--rakelib=""]
+    assert !@app.running?
+    assert was_running
+  end
+
 end


### PR DESCRIPTION
I have added a `Rake.application.running?` method, that returns true if Rake is running currently, and false otherwise. It is most useful to fence off code that is only needed for Rake tasks, or conversely, not needed. 

This is a common need in Rails apps and the most popular way to see if the code is running within a rake task is checking the command line argument (see SO answers at the bottom). Which might work, but it is messy, and leads to copy-paste of the `File.basename($0) == 'rake'` idiom.  Our project uses that code snippet in three distinct places, but instead of fixing this on a project level, in my opinion, this is a capability that Rake should have out of the box.

StackOverflow answers that suggest checking the script filename:

* https://stackoverflow.com/a/42619194/6678
* https://stackoverflow.com/a/15767148/6678