### PR TITLE
Force installation Bundler

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 clone_depth: 10
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - gem install bundler --no-document
+  - gem install bundler --no-document -f
   - bundle install
 build: off
 test_script:


### PR DESCRIPTION
AppVeyor says

```
gem install bundler --no-document
bundler's executable "bundle" conflicts with C:/Ruby200/bin/bundle
Overwrite the executable? [yN]
```

and it [timed out upon elapsing 1 hour](https://ci.appveyor.com/project/aycabta/rake/build/1.0.12). This commit adds `-f` option for it.