### PR TITLE
[skip ci] Fix minimal ruby version on README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -130,7 +130,7 @@ Rake is available under an MIT-style license.
 = Other stuff
 
 Author::   Jim Weirich <jim.weirich@gmail.com>
-Requires:: Ruby 1.9.3 or later
+Requires:: Ruby 2.0.0 or later
 License::  Copyright Jim Weirich.
            Released under an MIT-style license.  See the MIT-LICENSE
            file included in the distribution.


### PR DESCRIPTION
According to rake.gemspec, rake requires at least ruby 2.0.0

https://github.com/ruby/rake/blob/f35ce833db6976fcad0f9315689098cdb8e6d833/rake.gemspec#L33