### PR TITLE
[Fixes #246] Don't run file tasks needlessly

### DIFF
--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -30,14 +30,7 @@ module Rake
 
     # Are there any prerequisites with a later time than the given time stamp?
     def out_of_date?(stamp)
-      all_prerequisite_tasks.any? { |prereq|
-        prereq_task = application[prereq, @scope]
-        if prereq_task.instance_of?(Rake::FileTask)
-          prereq_task.timestamp > stamp || @application.options.build_all
-        else
-          prereq_task.timestamp > stamp
-        end
-      }
+      @prerequisites.any? { |n| application[n, @scope].timestamp > stamp }
     end
 
     # ----------------------------------------------------------------

--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -30,7 +30,7 @@ module Rake
 
     # Are there any prerequisites with a later time than the given time stamp?
     def out_of_date?(stamp)
-      @prerequisites.any? { |n| application[n, @scope].timestamp > stamp }
+      prerequisite_tasks.any? { |task| task.timestamp > stamp }
     end
 
     # ----------------------------------------------------------------

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -78,24 +78,6 @@ end
     DEFAULT
   end
 
-  def rakefile_file_chains
-    rakefile <<-RAKEFILE
-file "fileA" do |t|
-  sh "echo contentA >\#{t.name}"
-end
-
-file "fileB" => "fileA" do |t|
-  sh "(cat fileA; echo transformationB) >\#{t.name}"
-end
-
-file "fileC" => "fileB" do |t|
-  sh "(cat fileB; echo transformationC) >\#{t.name}"
-end
-
-task default: "fileC"
-    RAKEFILE
-  end
-
   def rakefile_comments
     rakefile <<-COMMENTS
 # comment for t1

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -296,26 +296,6 @@ class TestRakeFunctional < Rake::TestCase
            "'play.app' file should exist"
   end
 
-  def dryrun_tasks
-    @err.split("\n").select { |line|
-      line.match(/^\*\* Execute/)
-    }.map { |line|
-      line.gsub(/^\*\* Execute \(dry run\) /, "")
-    }
-  end
-
-  def test_update_midway_through_chaining_to_file_task
-    rakefile_file_chains
-
-    rake "-n"
-    assert_equal(%w{fileA fileB fileC default}, dryrun_tasks)
-    rake
-    sleep 1 # Ensure the timestamp is on a new second
-    FileUtils.touch("fileA")
-    rake "-n"
-    assert_equal(%w{fileB fileC default}, dryrun_tasks)
-  end
-
   def test_file_creation_task
     rakefile_file_creation
 


### PR DESCRIPTION
This PR:

* Fixes issue #246 by reverting PR #183, which was attempting to fix issue #92, which it seems to me not an actual issue. See comment https://github.com/ruby/rake/issues/92#issuecomment-363788202.