### PR TITLE
Remove date field from rake.gemspec

### DIFF
--- a/rake.gemspec
+++ b/rake.gemspec
@@ -5,7 +5,6 @@ require 'rake/version'
 Gem::Specification.new do |s|
   s.name = "rake".freeze
   s.version = Rake::VERSION
-  s.date = "2017-11-15"
   s.authors = ["Hiroshi SHIBATA".freeze, "Eric Hodel".freeze, "Jim Weirich".freeze]
   s.email = ["hsbt@ruby-lang.org".freeze, "drbrain@segment7.net".freeze, "".freeze]
 


### PR DESCRIPTION
Hi there :wave:

I noticed that in [this commit](https://github.com/ruby/rake/commit/6258ad54fcac8916394cc49ee306d1fd7aa05ca8) you bumped the version but did not change the `date` field in the `rake.gemspec`. This means that on rubygems.org, Rake 12.2.1 and Rake 12.3.0 were seemingly released on the same day, but the commits show a different history. (The last released date was [this commit](https://github.com/ruby/rake/commit/e7ea2d15890c4b204f5fc558f5a7c65384abf586) but it has since been bumped on master with [this commit](https://github.com/ruby/rake/commit/0c4aab882547bdd14b3dfde93e0bb02ad26ff088).


May I suggest removing the `date` field from the `gemspec`? This way, RubyGems.org will automatically assign the current date to the package's release _and_ it means that you as a maintainer will have to do one less thing every time you release a new version. We do not have a `date` field in the [`i18n` gem's `gemspec`](https://github.com/svenfuchs/i18n/blob/master/i18n.gemspec) and it works just fine. 

What do you think?