### PR TITLE
Removes duplicated inclusion of Rake::DSL

### DIFF
--- a/test/test_rake_file_creation_task.rb
+++ b/test/test_rake_file_creation_task.rb
@@ -4,7 +4,6 @@ require "fileutils"
 
 class TestRakeFileCreationTask < Rake::TestCase
   include Rake
-  include Rake::DSL
 
   DUMMY_DIR = "dummy_dir"
 

--- a/test/test_rake_multi_task.rb
+++ b/test/test_rake_multi_task.rb
@@ -4,7 +4,6 @@ require "thread"
 
 class TestRakeMultiTask < Rake::TestCase
   include Rake
-  include Rake::DSL
 
   def setup
     super


### PR DESCRIPTION
`Rake::DSL` is already included in `Rake::TestCase`