### PR TITLE
[Fixes #260] Make space trimming consistent for all task arguments

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -172,7 +172,7 @@ module Rake
       args = []
 
       begin
-        /((?:[^\\,]|\\.)*?)\s*(?:,\s*(.*))?$/ =~ remaining_args
+        /\s*((?:[^\\,]|\\.)*?)\s*(?:,\s*(.*))?$/ =~ remaining_args
 
         remaining_args = $2
         args << $1.gsub(/\\(.)/, '\1')

--- a/test/test_rake_task_argument_parsing.rb
+++ b/test/test_rake_task_argument_parsing.rb
@@ -32,6 +32,12 @@ class TestRakeTaskArgumentParsing < Rake::TestCase
     assert_equal ["one", "two"], args
   end
 
+  def test_can_handle_spaces_between_args
+    name, args = @app.parse_task_string("name[one, two,\tthree , \tfour]")
+    assert_equal "name", name
+    assert_equal ["one", "two", "three", "four"], args
+  end
+
   def test_can_handle_spaces_between_all_args
     name, args = @app.parse_task_string("name[ one , two ,\tthree , \tfour ]")
     assert_equal "name", name

--- a/test/test_rake_task_argument_parsing.rb
+++ b/test/test_rake_task_argument_parsing.rb
@@ -32,8 +32,8 @@ class TestRakeTaskArgumentParsing < Rake::TestCase
     assert_equal ["one", "two"], args
   end
 
-  def test_can_handle_spaces_between_args
-    name, args = @app.parse_task_string("name[one, two,\tthree , \tfour]")
+  def test_can_handle_spaces_between_all_args
+    name, args = @app.parse_task_string("name[ one , two ,\tthree , \tfour ]")
     assert_equal "name", name
     assert_equal ["one", "two", "three", "four"], args
   end


### PR DESCRIPTION
Fixes #260

Given a task that just inspect task arguments...

Current rake behavior
```
$ bundle exec rake "inspect_args[  one  ,  two  ,  three  ]"
"  one"
"two"
"three"
```

With this PR changes
```
$ bundle exec rake "inspect_args[  one  ,  two  ,  three  ]"
"one"
"two"
"three"
```