### PR TITLE
support did_you_mean >= v1.2.0 which has a breaking change on formatters

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -61,16 +61,20 @@ module Rake
 
     def generate_message_for_undefined_task(task_name)
       message = "Don't know how to build task '#{task_name}' (see --tasks)"
+      message + generate_did_you_mean_suggestions(task_name)
+    end
 
-      suggestion_message = \
-        if defined?(::DidYouMean::SpellChecker) && defined?(::DidYouMean::Formatter)
-          suggestions = ::DidYouMean::SpellChecker.new(dictionary: @tasks.keys).correct(task_name.to_s)
-          ::DidYouMean::Formatter.new(suggestions).to_s
-        else
-          ""
-        end
+    def generate_did_you_mean_suggestions(task_name)
+      return "" unless defined?(::DidYouMean::SpellChecker)
 
-      message + suggestion_message
+      suggestions = ::DidYouMean::SpellChecker.new(dictionary: @tasks.keys).correct(task_name.to_s)
+      if ::DidYouMean.respond_to?(:formatter)# did_you_mean v1.2.0 or later
+        ::DidYouMean.formatter.message_for(suggestions)
+      elsif defined?(::DidYouMean::Formatter) # before did_you_mean v1.2.0
+        ::DidYouMean::Formatter.new(suggestions).to_s
+      else
+        ""
+      end
     end
 
     def synthesize_file_task(task_name) # :nodoc:


### PR DESCRIPTION
did_you_mean  v1.2.0 has a breaking change to its formatter api:

https://github.com/yuki24/did_you_mean/compare/v1.1.2...v1.2.0

This PR uses the new `DidYouMean.formatter`, keeping backward compatibility for did_you_mean pre-1.2.0.