### PR TITLE
Add regexp capturing in rules

### DIFF
--- a/test/test_rake_rules.rb
+++ b/test/test_rake_rules.rb
@@ -409,4 +409,93 @@ class TestRakeRules < Rake::TestCase
     assert_equal [MINFILE], @runs
   end
 
+  def test_regex_rule_with_proc_dependent_with_capture
+    mkdir_p("src/jw")
+    create_file("src/jw/X.java")
+    rule %r(classes/(.*)\.class) => [
+      proc { "src/#{$1}.java" }
+    ] do |task|
+      assert_equal task.name, "classes/jw/X.class"
+      assert_equal task.source, "src/jw/X.java"
+      assert_equal $1, "jw/X"
+      @runs << :RULE
+    end
+    Task["classes/jw/X.class"].invoke
+    assert_equal [:RULE], @runs
+  end
+
+  def test_regex_rule_with_capture_in_action
+    create_file("icon.svg")
+    rule %r(-(\d+)x(\d+)\.png$) => [
+      ".svg"
+    ] do |task|
+      assert_equal task.name, "icon-160x120.png"
+      assert_equal task.source, "icon.svg"
+      assert_equal $`, "icon"
+      assert_equal $1, "160"
+      assert_equal $2, "120"
+      @runs << :RULE
+    end
+    Task["icon-160x120.png"].invoke
+    assert_equal [:RULE], @runs
+  end
+
+  def test_regex_rule_with_named_capture
+    create_file("icon.png")
+    rule %r(-(?<width>\d+)x(?<height>\d+)\.(?<ext>\w+)$) => [
+      '.\k<ext>'
+    ] do |task|
+      assert_equal task.name, "icon-160x120.png"
+      assert_equal task.source, "icon.png"
+      assert_equal $`, "icon"
+      assert_equal $~[:width], "160"
+      assert_equal $~[:height], "120"
+      assert_equal $~[:ext], "png"
+      @runs << :RULE
+    end
+    Task["icon-160x120.png"].invoke
+    assert_equal [:RULE], @runs
+  end
+
+  def test_regex_rule_with_proc_dependent_with_named_capture
+    mkdir_p("src/jw")
+    create_file("src/jw/X.java")
+    rule %r(classes/(?<basename>.*)\.class$) => [
+      proc { "src/#{$~[:basename]}.java" }
+    ] do |task|
+      assert_equal task.name, "classes/jw/X.class"
+      assert_equal task.source, "src/jw/X.java"
+      assert_equal $1, "jw/X"
+      assert_equal $~[:basename], "jw/X"
+      @runs << :RULE
+    end
+    Task["classes/jw/X.class"].invoke
+    assert_equal [:RULE], @runs
+  end
+
+  def test_regex_rule_with_string_dependent_with_named_capture
+    mkdir_p("src/jw")
+    create_file("src/jw/X.java")
+    rule %r(classes/(?<basename>.*)\.class) => [
+      'src/\k<basename>.java'
+    ] do |task|
+      assert_equal task.name, "classes/jw/X.class"
+      assert_equal task.source, "src/jw/X.java"
+      assert_equal $1, "jw/X"
+      assert_equal $~[:basename], "jw/X"
+      @runs << :RULE
+    end
+    Task["classes/jw/X.class"].invoke
+    assert_equal [:RULE], @runs
+  end
+
+  def test_regex_rule_with_backreference_prematch
+    create_file(SRCFILE)
+    rule ".o" => '\`.c' do |t|
+      @runs << t.name
+    end
+    Task[OBJFILE].invoke
+    assert_equal [OBJFILE], @runs
+  end
+
 end


### PR DESCRIPTION
This PR allows regexp capturing and backreferencing to `task_pattern` in rules.

``` ruby
rule task_pattern => source do |task|
  # action
end
```
- `Regexp.last_match` (`$~`) will be set in `Proc`s at both `source` and `action`.
  - Other `last_match` related special variables, such as `$1`, `$&`, `` $` ``, and `$'`, will also be set.
- If `source` is a `String`, it may contain backreferences to `task_pattern` by same format as `String#sub`.

Here are some examples:
``` ruby
rule /^(.*)-(\d+)x(\d+)\.png$/ => [     # regexp with capture groups
  proc { "#{$1}.svg" }                  # capture variable in a source proc
  # or '\1.svg'                         # backreference in a source string
] do |task|
  basename, width, height = $1, $2, $3  # capture variables in an action proc
  sh "convert #{basename}.svg -resize #{width}x#{height} #{basename}-#{width}x#{height}.png"
end
```
This can make `icon-32x32.png` from `icon.svg`.

``` ruby
rule /-(?<width>\d+)x(?<height>\d+).(?<ext>png|jpg)$/ => [ # regexp with named capture groups
  proc { "#{$`}.#{$~[:ext]}" }                             # matchdata in a source proc
  # or '\`.\k<ext>'                                        # named backreference in a source string
  # or '.\k<ext>'                                          # file extension replacement (already implemented in the current master branch)
] do |task|
  sh "convert #{task.source} -resize #{$~[:width]}x#{$~[:height]} #{task.name}" # accessing named capture groups
end
```

``` ruby
rule %r{^build/(?<basename>.*?)\.html\.(?<lang>.*?)$} => [
  'doc/\k<lang>/\k<basename>.md'                           # named backreference in a source string
] do
  sh "pandoc -o #{task.name} #{task.source}"
end
```
This can make `build/index.html.en` from `doc/en/index.md`.

Although it passes all the tests, it will break backward compatibility in some cases:

- `Proc`s that refer to `Regexp.last_match` related variables assigned outside the rule block
- `String` sources that include backslashes (directory separator in Windows?)

Former case example:
``` ruby
options.match(/^CFLAGS=(.*)$/)  # extract a parameter from a multiline text

rule '.o' => '.c' do |task|
  sh "gcc #{$1} -c -o #{task.name} #{task.source}   # $1 will be replaced to nil
end
```

Any feedback would be appreciated. Thanks.