### PR TITLE
Fix JRuby detection on JRuby 9.2 in cpu_counter.rb

### DIFF
--- a/lib/rake/cpu_counter.rb
+++ b/lib/rake/cpu_counter.rb
@@ -32,7 +32,7 @@ unless Rake::CpuCounter.method_defined?(:count)
     require 'rbconfig'
 
     def count
-      if defined?(Java::Java)
+      if defined?(JRUBY_VERSION) && (Java::Java rescue nil)
         count_via_java_runtime
       else
         case RbConfig::CONFIG['host_os']

--- a/lib/rake/cpu_counter.rb
+++ b/lib/rake/cpu_counter.rb
@@ -32,7 +32,7 @@ unless Rake::CpuCounter.method_defined?(:count)
     require 'rbconfig'
 
     def count
-      if defined?(JRUBY_VERSION) && (Java::Java rescue nil)
+      if RUBY_PLATFORM == 'java'
         count_via_java_runtime
       else
         case RbConfig::CONFIG['host_os']


### PR DESCRIPTION
`Java::Java` is no longer defined by default, it's not defined until it is accessed:

```
$ jruby -e 'p defined?(Java::Java)'
nil
$ jruby -e 'p Java::Java'
Java::Java
```

In earlier JRuby versions, `defined?(Java::Java)` returned `"constant"`.

While this doesn't cause an test failures, it does result in the following warning when run on non-Windows systems: `!!!! Missing jruby-win32ole gem: jruby -S gem install jruby-win32ole`, because the first fallback code is to try to load `win32ole`, and on JRuby that prints the warning.

