### PR TITLE
Fixed bug: Reenabled task raises previous exception on second invokation

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -141,7 +141,8 @@ module Rake
     # Reenable the task, allowing its tasks to be executed if the task
     # is invoked again.
     def reenable
-      @already_invoked = false
+      @already_invoked      = false
+      @invocation_exception = nil
     end
 
     # Clear the existing prerequisites, actions, comments, and arguments of a rake task.

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -141,7 +141,7 @@ module Rake
     # Reenable the task, allowing its tasks to be executed if the task
     # is invoked again.
     def reenable
-      @already_invoked      = false
+      @already_invoked = false
       @invocation_exception = nil
     end
 

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -117,6 +117,33 @@ class TestRakeTask < Rake::TestCase
     assert_equal ["t1", "t1"], runlist
   end
 
+  def test_can_triple_invoke_after_exception_with_reenable
+    raise_exception = true
+    invoked         = 0
+
+    t1 = task(:t1) do |t|
+      invoked += 1
+      next if !raise_exception
+
+      raise_exception = false
+      raise 'Some error'
+    end
+
+    assert_raises(RuntimeError) { t1.invoke }
+    assert_equal 1, invoked
+
+    t1.reenable
+
+    # actually invoke second time
+    t1.invoke
+    assert_equal 2, invoked
+
+    # recognize already invoked and
+    # don't raise pre-reenable exception
+    t1.invoke
+    assert_equal 2, invoked
+  end
+
   def test_clear
     desc "a task"
     t = task("t", ["b"] => "a") {}


### PR DESCRIPTION
After a task is `reenable`d an exception of the pre-`reenable` invocation should not be raised but is.

