### PR TITLE
Improve multitask performance

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -248,7 +248,8 @@ module Rake
           r.invoke_with_call_chain(prereq_args, invocation_chain)
         end
       end
-      futures.each(&:value)
+      # Iterate in reverse to improve performance related to thread waiting and switching
+      futures.reverse_each(&:value)
     end
 
     # Format the trace flags for display.


### PR DESCRIPTION
Thread context switches are expensive, iterating through promises in reverse minimizes them.

See my blog post about it here: https://medium.com/@sanmiguelje/optimizing-rake-multitask-fece36a16c8f