### PR TITLE
fix errors in rubocop

### DIFF
--- a/lib/rake/packagetask.rb
+++ b/lib/rake/packagetask.rb
@@ -132,9 +132,7 @@ module Rake
           task package: ["#{package_dir}/#{file}"]
           file "#{package_dir}/#{file}" =>
             [package_dir_path] + package_files do
-            chdir(package_dir) do
-              sh @tar_command, "#{flag}cvf", file, package_name
-            end
+            chdir(package_dir) { sh @tar_command, "#{flag}cvf", file, package_name }
           end
         end
       end
@@ -143,9 +141,7 @@ module Rake
         task package: ["#{package_dir}/#{zip_file}"]
         file "#{package_dir}/#{zip_file}" =>
           [package_dir_path] + package_files do
-          chdir(package_dir) do
-            sh @zip_command, "-r", zip_file, package_name
-          end
+          chdir(package_dir) { sh @zip_command, "-r", zip_file, package_name }
         end
       end
 


### PR DESCRIPTION
There is currently a couple of errors in rubocop that this PR is fixing:

```
❯ rubocop

Inspecting 97 files
...........................................................E.....................................

Offenses:

lib/rake/packagetask.rb:135:32: E: Lint/Syntax: unexpected token kDO_BLOCK
(Using Ruby 2.3 parser; configure using TargetRubyVersion parameter, under AllCops)
            chdir(package_dir) do
                               ^^
lib/rake/packagetask.rb:146:30: E: Lint/Syntax: unexpected token kDO_BLOCK
(Using Ruby 2.3 parser; configure using TargetRubyVersion parameter, under AllCops)
          chdir(package_dir) do
                             ^^
lib/rake/packagetask.rb:209:3: E: Lint/Syntax: unexpected token kEND
(Using Ruby 2.3 parser; configure using TargetRubyVersion parameter, under AllCops)
  end
  ^^^

97 files inspected, 3 offenses detected
```