### PR TITLE
restrict rubocop to 0.50.0 and set Ruby parser to 2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.0
   DisabledByDefault: true
   Exclude:
     - doc/**/*.rb
@@ -52,6 +52,6 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/CaseIndentation:
   Enabled: true
 
-Layout/EndAlignment:
+Lint/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable

--- a/rake.gemspec
+++ b/rake.gemspec
@@ -38,5 +38,5 @@ Rake has the following features:
   s.add_development_dependency(%q<minitest>.freeze)
   s.add_development_dependency(%q<rdoc>.freeze)
   s.add_development_dependency(%q<coveralls>.freeze)
-  s.add_development_dependency(%q<rubocop>.freeze)
+  s.add_development_dependency(%q<rubocop>.freeze, '~> 0.50.0')
 end


### PR DESCRIPTION
This PR is a bit nitpicky, so feel free to close this. I noticed that in `.travis.yml` that ruby 2.0 is being tested. It would be great to set rubocop to match the lowest supported version so that Rubocop doesn't suggests a change that Ruby 2.0 doesn't support