### PR TITLE
Add rubocop into Travis-CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - doc/**/*.rb
     - rake.gemspec
+    - bin/*
 
 Metrics/LineLength:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,7 @@ rvm:
 before_script:
   - unset JRUBY_OPTS
   - unset _JAVA_OPTIONS
-script: ruby -Ilib exe/rake
+  - bundle install
+script:
+  - rubocop
+  - ruby -Ilib exe/rake

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -172,7 +172,8 @@ class TestRakeTask < Rake::TestCase
     task :tfind
     assert_equal "tfind", Task[:tfind].name
     ex = assert_raises(RuntimeError) { Task[:leaves] }
-    assert_equal "Don't know how to build task 'leaves' (See the list of available tasks with `rake --tasks`)", ex.message
+    assert_equal "Don't know how to build task 'leaves' (See the" \
+      " list of available tasks with `rake --tasks`)", ex.message
   end
 
   def test_defined


### PR DESCRIPTION
Note: This PR depends on #282 being merged first.

This PR adds a step in Travis to run rubocop. This would be very beneficial to the project because it makes sure that any new changes to rake conform to the existing style guide.