### PR TITLE
run coveralls in CI only

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,9 +2,11 @@
 $:.unshift File.expand_path("../../lib", __FILE__)
 
 begin
-  gem "coveralls"
-  require "coveralls"
-  Coveralls.wear!
+  if ENV['CI']
+    gem "coveralls"
+    require "coveralls"
+    Coveralls.wear!
+  end
 rescue Gem::LoadError
 end
 


### PR DESCRIPTION
When running Rake's test suite, i noticed that the `coveralls` gem is being executed. This doesn't need to be loaded in dev and can be restricted to only load in Travis CI/AppVeyor.