### PR TITLE
Rework the error message that tells users to list the tasks with `rake --tasks`

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -60,7 +60,7 @@ module Rake
     end
 
     def generate_message_for_undefined_task(task_name)
-      message = "Don't know how to build task '#{task_name}' (see --tasks)"
+      message = "Don't know how to build task '#{task_name}' (See the list of available tasks with `rake --tasks`)"
       message + generate_did_you_mean_suggestions(task_name)
     end
 

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -172,7 +172,7 @@ class TestRakeTask < Rake::TestCase
     task :tfind
     assert_equal "tfind", Task[:tfind].name
     ex = assert_raises(RuntimeError) { Task[:leaves] }
-    assert_equal "Don't know how to build task 'leaves' (see --tasks)", ex.message
+    assert_equal "Don't know how to build task 'leaves' (See the list of available tasks with `rake --tasks`)", ex.message
   end
 
   def test_defined

--- a/test/test_rake_task_manager.rb
+++ b/test/test_rake_task_manager.rb
@@ -25,7 +25,7 @@ class TestRakeTaskManager < Rake::TestCase
       @tm["bad"]
     end
 
-    assert_equal "Don't know how to build task 'bad' (see --tasks)", e.message
+    assert_equal "Don't know how to build task 'bad' (See the list of available tasks with `rake --tasks`)", e.message
   end
 
   def test_name_lookup


### PR DESCRIPTION
This PR is reworking the error message when a given task does not exist.

```
$ rake foo
rake aborted!
Don't know how to build task 'foo' (see --tasks)
/Users/colby/.gem/ruby/2.5.1/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
```
There is a good opportunity here to reword the `(see --tasks)` into something more meaningful and direct.

Users may not be aware of the `rake --tasks` option, so this PR adjusts the error message to instead be direct in saying that you can see a list of available tasks using this command. 

I've turned it into this, which i think provides better communication to users:

```
Don't know how to build task 'foo' (See the list of available tasks with `rake --tasks`)
```
