### PR TITLE
fix links to rake resources not showing on Github

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -75,10 +75,10 @@ Type "rake --help" for all available options.
 
 === Rake Information
 
-* {Rake command-line}[rdoc-ref:doc/command_line_usage.rdoc]
-* {Writing Rakefiles}[rdoc-ref:doc/rakefile.rdoc]
-* The original {Rake announcement}[rdoc-ref:doc/rational.rdoc]
-* Rake {glossary}[rdoc-ref:doc/glossary.rdoc]
+* {Rake command-line}[link:doc/command_line_usage.rdoc]
+* {Writing Rakefiles}[link:doc/rakefile.rdoc]
+* The original {Rake announcement}[link:doc/rational.rdoc]
+* Rake {glossary}[link:doc/glossary.rdoc]
 
 === Presentations and Articles about Rake
 


### PR DESCRIPTION
There is a set of resources listed in the README that's suppose to be linking to pages in the repo but isn't. The resources are:

<img width="444" alt="screen shot 2018-11-05 at 8 28 51 pm" src="https://user-images.githubusercontent.com/996377/47989565-70ffd500-e139-11e8-9ac5-0c587e5204bc.png">

Looking into this, i did stumble across https://github.com/ruby/rake/pull/6 to fix this issue but was declined. But IMO this should be fixed so that people can be correctly linked to the listed resources on Github.