### PR TITLE
run coveralls only when COVERALLS env var is present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ rvm:
   - ruby-head
   - jruby-9.1.16.0
   - jruby-head
+
+matrix:
+  include:
+    - rvm: 2.5.3
+      env: COVERALLS=yes
+
 before_script:
   - unset JRUBY_OPTS
   - unset _JAVA_OPTIONS

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,9 +2,11 @@
 $:.unshift File.expand_path("../../lib", __FILE__)
 
 begin
-  gem "coveralls"
-  require "coveralls"
-  Coveralls.wear!
+  if ENV['COVERALLS']
+    gem "coveralls"
+    require "coveralls"
+    Coveralls.wear!
+  end
 rescue Gem::LoadError
 end
 


### PR DESCRIPTION
This is to prevent multiple travis-ci jobs running coveralls and results in the coveralls posting multiple reports per PR.

See:
- https://github.com/ruby/rake/pull/288
- https://github.com/ruby/rake/pull/283

