### PR TITLE
update latest jruby version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - ruby-head
-  - jruby-9.1.16.0
+  - jruby-9.2.0.0
   - jruby-head
 before_script:
   - unset JRUBY_OPTS


### PR DESCRIPTION
This PR is just updating the version of JRuby used in travis-ci to the latest version.