### PR TITLE
Update public clone URL to use https

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -3,7 +3,7 @@
 Rake is currently hosted at github. The github web page is
 https://github.com/ruby/rake . The public git clone URL is
 
-  git://github.com/ruby/rake.git
+  https://github.com/ruby/rake.git
 
 = Running the Rake Test Suite
 


### PR DESCRIPTION
This is a bit nitpicky -  so feel free to close this. This PR is updating the URL for the public repository in the rake documentation to use `https` instead because security & privacy are 👍 