### PR TITLE
Improve running test instructions and denote commands with `$`

### DIFF
--- a/CONTRIBUTING.rdoc
+++ b/CONTRIBUTING.rdoc
@@ -12,18 +12,18 @@ If you wish to run the unit and functional tests that come with Rake:
 * +cd+ into the top project directory of rake.
 * Install gem dependency using bundler:
 
-    bundle install  # Install bundler, minitest and rdoc
+    $ bundle install  # Install bundler, minitest and rdoc
 
-* Type one of the following:
+* Run the test suite
 
-    rake            # If you have run rake's tests
+    $ rake
 
 = Rubocop
 
 Rake uses Rubocop to enforce a consistent style on new changes being
 proposed. You can check your code with Rubocop using:
 
-  ./bin/rubocop
+  $ ./bin/rubocop
 
 = Issues and Bug Reports
 


### PR DESCRIPTION
This PR is adjusting a couple of things:

Improve the instructions around running Rake's test suite. I think the instructions may have been left-over from a previous form and wasn't making a huge amount of sense. 

The second is denoting commands with the `$` prefix. This is a typical convention in documentation and helpful for new contributors.