### PR TITLE
Use Regexp#=== to match loosely

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -392,7 +392,7 @@ module Rake
 
     def sort_options(options) # :nodoc:
       options.sort_by { |opt|
-        opt.select { |o| o =~ /^-/ }.map(&:downcase).sort.reverse
+        opt.select { |o| /\A-/ === o }.map(&:downcase).sort.reverse
       }
     end
     private :sort_options


### PR DESCRIPTION
Till ruby 2.5, `Object#=~` silently ignored non-string argument, but it has been deprecated since ruby 2.6 and will be removed in the future.  Use `Regexp#===` instead, to match loosely.

Also `/^-/` is not a proper pattern to tell if the argument starts with a `-`.