### PR TITLE
Add ruby 2.6.0 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
   - ruby-head
   - jruby-9.2.4.0
   - jruby-head
@@ -19,4 +20,6 @@ matrix:
 before_script:
   - unset JRUBY_OPTS
   - unset _JAVA_OPTIONS
+  - if ruby -e "exit RUBY_VERSION >= '2.3.0'"; then gem update --system=3.0.1; else gem update --system=2.7.8; fi
+
 script: ruby -Ilib exe/rake


### PR DESCRIPTION
This PR adds Ruby 2.6 to Travis-CI.

Note that We have to manually update RubyGems because Travis forces each ruby
version to have an old version of RubyGems, which breaks our tests in 2.6.