### PR TITLE
Use the application's name in error message if a task is not found

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -60,7 +60,8 @@ module Rake
     end
 
     def generate_message_for_undefined_task(task_name)
-      message = "Don't know how to build task '#{task_name}' (See the list of available tasks with `rake --tasks`)"
+      message = "Don't know how to build task '#{task_name}' "\
+                "(See the list of available tasks with `#{Rake.application.name} --tasks`)"
       message + generate_did_you_mean_suggestions(task_name)
     end
 

--- a/test/test_rake_task_manager.rb
+++ b/test/test_rake_task_manager.rb
@@ -28,6 +28,16 @@ class TestRakeTaskManager < Rake::TestCase # :nodoc:
     assert_equal "Don't know how to build task 'bad' (See the list of available tasks with `rake --tasks`)", e.message
   end
 
+  def test_undefined_task_with_custom_application
+    Rake.application.init("myrake", nil)
+
+    e = assert_raises RuntimeError do
+      @tm["bad"]
+    end
+
+    assert_equal "Don't know how to build task 'bad' (See the list of available tasks with `myrake --tasks`)", e.message
+  end
+
   def test_name_lookup
     t = @tm.define_task(Rake::Task, :t)
     assert_equal t, @tm[:t]


### PR DESCRIPTION
`Rake.application` can be initialized with a custom name, so use that in the error message when a task is not found in the index. The default application name is `rake`.

Amends #287