### PR TITLE
Make `PackageTask` be able to omit parent directory while packing files

### DIFF
--- a/lib/rake/packagetask.rb
+++ b/lib/rake/packagetask.rb
@@ -79,6 +79,9 @@ module Rake
     # Zip command for zipped archives.  The default is 'zip'.
     attr_accessor :zip_command
 
+    # True if parent directory should be omited (default is false)
+    attr_accessor :without_parent_dir
+
     # Create a Package Task with the given name and version.  Use +:noversion+
     # as the version to build a package without a version or to provide a
     # fully-versioned package name.
@@ -102,6 +105,7 @@ module Rake
       @need_zip = false
       @tar_command = "tar"
       @zip_command = "zip"
+      @without_parent_dir = false
     end
 
     # Create the tasks defined by this task library.
@@ -132,7 +136,8 @@ module Rake
           task package: ["#{package_dir}/#{file}"]
           file "#{package_dir}/#{file}" =>
             [package_dir_path] + package_files do
-            chdir(package_dir) { sh @tar_command, "#{flag}cvf", file, package_name }
+            chdir(working_dir) { sh @tar_command, "#{flag}cvf", file, target_dir }
+            mv "#{package_dir_path}/#{target_dir}", package_dir if without_parent_dir
           end
         end
       end
@@ -141,7 +146,8 @@ module Rake
         task package: ["#{package_dir}/#{zip_file}"]
         file "#{package_dir}/#{zip_file}" =>
           [package_dir_path] + package_files do
-          chdir(package_dir) { sh @zip_command, "-r", zip_file, package_name }
+          chdir(working_dir) { sh @zip_command, "-r", zip_file, target_dir }
+          mv "#{package_dir_path}/#{zip_file}", package_dir if without_parent_dir
         end
       end
 
@@ -201,6 +207,15 @@ module Rake
 
     def zip_file
       "#{package_name}.zip"
+    end
+
+    def working_dir
+      without_parent_dir ? package_dir_path : package_dir
+    end
+
+    # target directory relative to working_dir
+    def target_dir
+      without_parent_dir ? "." : package_name
     end
   end
 

--- a/test/test_rake_package_task.rb
+++ b/test/test_rake_package_task.rb
@@ -78,4 +78,16 @@ class TestRakePackageTask < Rake::TestCase # :nodoc:
     assert_equal "a", pkg.package_name
   end
 
+  def test_without_parent_dir
+    pkg = Rake::PackageTask.new("foo", :noversion)
+
+    assert_equal "pkg", pkg.working_dir
+    assert_equal "foo", pkg.target_dir
+
+    pkg.without_parent_dir = true
+
+    assert_equal "pkg/foo", pkg.working_dir
+    assert_equal ".", pkg.target_dir
+  end
+
 end


### PR DESCRIPTION
# Expected

```
$ unzip -l pkg/my_browser_extension-1.0.1.zip
Archive:  pkg/my_browser_extension-1.0.1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      469  04-17-2019 17:02   manifest.json
        0  04-19-2019 17:57   src/
     1417  04-19-2019 11:55   src/main.js
        0  04-19-2019 17:57   src/icons/
     1946  04-17-2019 12:28   src/icons/48.png
     5262  04-17-2019 12:29   src/icons/128.png
      625  04-17-2019 12:28   src/icons/16.png
---------                     -------
     9719                     7 files
```

# Actual

```
$ unzip -l pkg/my_browser_extension-1.0.1.zip
Archive:  pkg/my_browser_extension-1.0.1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  04-19-2019 17:57   my_browser_extension-1.0.1/
      469  04-17-2019 17:02   my_browser_extension-1.0.1/manifest.json
        0  04-19-2019 17:57   my_browser_extension-1.0.1/src/
     1417  04-19-2019 11:55   my_browser_extension-1.0.1/src/main.js
        0  04-19-2019 17:57   my_browser_extension-1.0.1/src/icons/
     1946  04-17-2019 12:28   my_browser_extension-1.0.1/src/icons/48.png
     5262  04-17-2019 12:29   my_browser_extension-1.0.1/src/icons/128.png
      625  04-17-2019 12:28   my_browser_extension-1.0.1/src/icons/16.png
---------                     -------
     9719                     8 files
```

# Why Do We Need This Feature?

The problem emerged when I want to use `PackageTask` to package my Chrome/Firefox extension. `PackageTask` can only package the whole directory but Mozilla does not accept such structure:

> The ZIP file must be a ZIP of the extension's files themselves, not of the directory containing them.
>
> https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Package_your_extension_

# Before (Workaround)

There is no way to omit parent directory by set config to `PackageTask`, alternatively below is a workaround to achieve this:

```ruby
Rake::PackageTask.new('my_browser_extension', version) do |pkg|
  pkg.package_files.include('src/**/*', 'manifest.json')
  file "#{pkg.package_dir}/#{pkg.zip_file}" => [pkg.package_dir_path] + pkg.package_files do
    chdir(pkg.package_dir_path) { sh pkg.zip_command, '-r', pkg.zip_file, '.' }
    mv "#{pkg.package_dir_path}/#{pkg.zip_file}", pkg.package_dir
  end
  task default: "#{pkg.package_dir}/#{pkg.zip_file}"
end
```

# After

With this pull request, we can now make it easier:

```ruby
Rake::PackageTask.new('my_browser_extension', version) do |pkg|
  pkg.package_files.include('src/**/*', 'manifest.json')
  pkg.need_zip = true
  pkg.without_parent_dir = true
end
```
