### PR TITLE
Add tasks.rb to accepted default rake files

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -42,7 +42,8 @@ module Rake
       "rakefile",
       "Rakefile",
       "rakefile.rb",
-      "Rakefile.rb"
+      "Rakefile.rb",
+      "tasks.rb"
     ].freeze
 
     # Initialize a Rake::Application object.

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -411,6 +411,12 @@ end
     end
   end
 
+  def rakefile_tasks
+    open "tasks.rb", "w" do |io|
+      io << 'task :default do puts "OK" end'
+    end
+  end
+
   def rakefile_unittest
     rakefile "# Empty Rakefile for Unit Test"
 

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -97,6 +97,14 @@ class TestRakeFunctional < Rake::TestCase # :nodoc:
     assert_match %r{^OK$}, @out
   end
 
+  def test_tasks
+    rakefile_tasks
+
+    rake "-N"
+
+    assert_match %r{^OK$}, @out
+  end
+
   def test_system
     rake_system_dir
 


### PR DESCRIPTION
This is just a suggestion, but as it's ridiculously easy to implement, I'll jump directly to a PR:

Since Bundler is migrating from `Gemfile` to `gems.rb`, how about adding `tasks.rb` as an accepted alternative naming for `Rakefile`?

Another alternative to the existing ones would be `rake.rb`, however, me personally, I prefer to have a functionally descriptive name similar to `gems.rb` – at least for the most essential tools like Bundler and Rake. For less commonly used gems, naming the config file identical to the gem itself makes more sense (e.g. `guard.rb` for Guard).

Thanks for considering this addition!