### PR TITLE
Drop old ruby versions which are no longer tested

### DIFF
--- a/rake.gemspec
+++ b/rake.gemspec
@@ -29,7 +29,7 @@ Rake has the following features:
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib".freeze]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.0.0".freeze)
+  s.required_ruby_version = Gem::Requirement.new(">= 2.2".freeze)
   s.rubygems_version = "2.6.1".freeze
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.2".freeze)
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -77,9 +77,6 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
   end
 
   def test_display_exception_details_cause
-    skip "Exception#cause not implemented" unless
-      Exception.method_defined? :cause
-
     begin
       raise "cause a"
     rescue

--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -13,7 +13,6 @@ class TestBacktraceSuppression < Rake::TestCase # :nodoc:
 
   def test_system_dir_suppressed
     path = RbConfig::CONFIG["rubylibprefix"]
-    skip if path.nil?
     path = File.expand_path path
 
     paths = [path + ":12"]
@@ -25,7 +24,6 @@ class TestBacktraceSuppression < Rake::TestCase # :nodoc:
 
   def test_near_system_dir_isnt_suppressed
     path = RbConfig::CONFIG["rubylibprefix"]
-    skip if path.nil?
     path = File.expand_path path
 
     paths = [" " + path + ":12"]

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -212,7 +212,6 @@ class TestRakeFileList < Rake::TestCase # :nodoc:
   end
 
   def test_exclude_curly_bracket_pattern
-    skip "brace pattern matches not supported" unless defined? File::FNM_EXTGLOB
     fl = FileList["*"].exclude("{abc,xyz}.c")
     assert_equal %w[abc.h abc.x cfiles existing x.c xyzzy.txt], fl
   end

--- a/test/test_rake_task_with_arguments.rb
+++ b/test/test_rake_task_with_arguments.rb
@@ -82,9 +82,6 @@ class TestRakeTaskWithArguments < Rake::TestCase # :nodoc:
   end
 
   def test_actions_adore_keywords
-    # A brutish trick to avoid parsing. Remove it once support for 1.9 and 2.0 is dropped
-    # https://ci.appveyor.com/project/ruby/rake/build/1.0.301
-    skip "Keywords aren't a feature in this version" if RUBY_VERSION =~ /^1|^2\.0/
     # https://github.com/ruby/rake/pull/174#issuecomment-263460761
     skip if jruby9?
     eval <<-RUBY, binding, __FILE__, __LINE__+1


### PR DESCRIPTION
It doesn't seem working with ruby 2.1 already.

```
$ ruby2.1 -I./lib exe/rake 
/opt/local/bin/ruby2.1 -w -I"lib:test"  "/Users/nobu/src/ruby/rake/lib/rake/rake_test_loader.rb" "test/test_private_reader.rb" "test/test_rake.rb" "test/test_rake_application.rb" "test/test_rake_application_options.rb" "test/test_rake_backtrace.rb" "test/test_rake_clean.rb" "test/test_rake_cpu_counter.rb" "test/test_rake_definitions.rb" "test/test_rake_directory_task.rb" "test/test_rake_dsl.rb" "test/test_rake_early_time.rb" "test/test_rake_extension.rb" "test/test_rake_file_creation_task.rb" "test/test_rake_file_list.rb" "test/test_rake_file_list_path_map.rb" "test/test_rake_file_task.rb" "test/test_rake_file_utils.rb" "test/test_rake_functional.rb" "test/test_rake_invocation_chain.rb" "test/test_rake_late_time.rb" "test/test_rake_linked_list.rb" "test/test_rake_makefile_loader.rb" "test/test_rake_multi_task.rb" "test/test_rake_name_space.rb" "test/test_rake_package_task.rb" "test/test_rake_path_map.rb" "test/test_rake_path_map_explode.rb" "test/test_rake_path_map_partial.rb" "test/test_rake_pseudo_status.rb" "test/test_rake_rake_test_loader.rb" "test/test_rake_reduce_compat.rb" "test/test_rake_require.rb" "test/test_rake_rules.rb" "test/test_rake_scope.rb" "test/test_rake_task.rb" "test/test_rake_task_argument_parsing.rb" "test/test_rake_task_arguments.rb" "test/test_rake_task_manager.rb" "test/test_rake_task_manager_argument_resolution.rb" "test/test_rake_task_with_arguments.rb" "test/test_rake_test_task.rb" "test/test_rake_thread_pool.rb" "test/test_rake_top_level_functions.rb" "test/test_rake_win32.rb" "test/test_thread_history_display.rb" "test/test_trace_output.rb" 
/opt/local/lib/ruby2.1/2.1.0/rubygems/dependency.rb:298:in `to_specs': Could not find 'minitest' (~> 5) - did find: [minitest-4.7.5] (Gem::LoadError)
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/dependency.rb:309:in `to_spec'
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/core_ext/kernel_gem.rb:53:in `gem'
	from /Users/nobu/src/ruby/rake/test/helper.rb:13:in `<top (required)>'
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
	from /Users/nobu/src/ruby/rake/test/test_private_reader.rb:2:in `<top (required)>'
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
	from /opt/local/lib/ruby2.1/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
	from /Users/nobu/src/ruby/rake/lib/rake/rake_test_loader.rb:17:in `block in <main>'
	from /Users/nobu/src/ruby/rake/lib/rake/rake_test_loader.rb:5:in `select'
	from /Users/nobu/src/ruby/rake/lib/rake/rake_test_loader.rb:5:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test"  "/Users/nobu/src/ruby/rake/lib/rake/rake_test_loader.rb" "test/test_private_reader.rb" "test/test_rake.rb" "test/test_rake_application.rb" "test/test_rake_application_options.rb" "test/test_rake_backtrace.rb" "test/test_rake_clean.rb" "test/test_rake_cpu_counter.rb" "test/test_rake_definitions.rb" "test/test_rake_directory_task.rb" "test/test_rake_dsl.rb" "test/test_rake_early_time.rb" "test/test_rake_extension.rb" "test/test_rake_file_creation_task.rb" "test/test_rake_file_list.rb" "test/test_rake_file_list_path_map.rb" "test/test_rake_file_task.rb" "test/test_rake_file_utils.rb" "test/test_rake_functional.rb" "test/test_rake_invocation_chain.rb" "test/test_rake_late_time.rb" "test/test_rake_linked_list.rb" "test/test_rake_makefile_loader.rb" "test/test_rake_multi_task.rb" "test/test_rake_name_space.rb" "test/test_rake_package_task.rb" "test/test_rake_path_map.rb" "test/test_rake_path_map_explode.rb" "test/test_rake_path_map_partial.rb" "test/test_rake_pseudo_status.rb" "test/test_rake_rake_test_loader.rb" "test/test_rake_reduce_compat.rb" "test/test_rake_require.rb" "test/test_rake_rules.rb" "test/test_rake_scope.rb" "test/test_rake_task.rb" "test/test_rake_task_argument_parsing.rb" "test/test_rake_task_arguments.rb" "test/test_rake_task_manager.rb" "test/test_rake_task_manager_argument_resolution.rb" "test/test_rake_task_with_arguments.rb" "test/test_rake_test_task.rb" "test/test_rake_thread_pool.rb" "test/test_rake_top_level_functions.rb" "test/test_rake_win32.rb" "test/test_thread_history_display.rb" "test/test_trace_output.rb" ]
exe/rake:27:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```