### PR TITLE
Fix an incorrectly resolved arg pattern

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -133,8 +133,8 @@ module Rake
         deps = value || []
       else
         task_name = args.shift
-        arg_names = key
-        deps = value
+        arg_names = key || args.shift|| []
+        deps = value || []
       end
       deps = [deps] unless deps.respond_to?(:to_ary)
       [task_name, arg_names, deps, order_only]

--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -83,8 +83,8 @@ module Rake
       define_task(Rake::FileTask, task_name)
     end
 
-    # Resolve the arguments for a task/rule.  Returns a triplet of
-    # [task_name, arg_name_list, prerequisites].
+    # Resolve the arguments for a task/rule.  Returns a tuple of
+    # [task_name, arg_name_list, prerequisites, order_only_prerequisites].
     def resolve_args(args)
       if args.last.is_a?(Hash)
         deps = args.pop
@@ -118,8 +118,11 @@ module Rake
     #
     # The patterns recognized by this argument resolving function are:
     #
+    #   task :t, order_only: [:e]
     #   task :t => [:d]
+    #   task :t => [:d], order_only: [:e]
     #   task :t, [a] => [:d]
+    #   task :t, [a] => [:d], order_only: [:e]
     #
     def resolve_args_with_dependencies(args, hash) # :nodoc:
       fail "Task Argument Error" if

--- a/test/test_rake_task_manager_argument_resolution.rb
+++ b/test/test_rake_task_manager_argument_resolution.rb
@@ -8,9 +8,16 @@ class TestRakeTaskManagerArgumentResolution < Rake::TestCase # :nodoc:
     assert_equal [:t, [], [:x], nil],     task(t: :x)
     assert_equal [:t, [], [:x, :y], nil], task(t: [:x, :y])
 
+    assert_equal [:t, [], [], [:m]],           task(:t, order_only: [:m])
+    assert_equal [:t, [], [:x, :y], [:m, :n]], task(t: [:x, :y], order_only: [:m, :n])
+
     assert_equal [:t, [:a, :b], [], nil],       task(:t, [:a, :b])
     assert_equal [:t, [:a, :b], [:x], nil],     task(:t, [:a, :b] => :x)
     assert_equal [:t, [:a, :b], [:x, :y], nil], task(:t, [:a, :b] => [:x, :y])
+
+    assert_equal [:t, [:a, :b], [], [:m]],           task(:t, [:a, :b], order_only: [:m])
+    assert_equal [:t, [:a, :b], [:x], [:m]],         task(:t, [:a, :b] => :x, order_only: [:m])
+    assert_equal [:t, [:a, :b], [:x, :y], [:m, :n]], task(:t, [:a, :b] => [:x, :y], order_only: [:m, :n])
   end
 
   def task(*args)


### PR DESCRIPTION
I created addition some additional assertions in `test_good_arg_patterns` in advance of some changes I'm considering for `TaskManager#resolve_args`.  During that case, I found a case that returned unexpected results.  This pull contains the fix for that failing test case.

I updated some comments which didn't get updated in #269. 