### PR TITLE
Skip a taint test on Ruby 2.7

### DIFF
--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -496,13 +496,15 @@ class TestRakeFileList < Rake::TestCase # :nodoc:
     assert_equal ["a", "b", "c"], d
   end
 
-  def test_dup_and_clone_replicate_taint
-    a = FileList["a", "b", "c"]
-    a.taint
-    c = a.clone
-    d = a.dup
-    assert c.tainted?, "Clone should be tainted"
-    assert d.tainted?, "Dup should be tainted"
+  if RUBY_VERSION < '2.7'
+    def test_dup_and_clone_replicate_taint
+      a = FileList["a", "b", "c"]
+      a.taint
+      c = a.clone
+      d = a.dup
+      assert c.tainted?, "Clone should be tainted"
+      assert d.tainted?, "Dup should be tainted"
+    end
   end
 
   def test_duped_items_will_thaw


### PR DESCRIPTION
Ruby 2.7 is deprecating taint, and taint will no longer have an
effect. See https://bugs.ruby-lang.org/issues/16131.

This just skips the test for FileList#clone and #dup copying the
taint flag on Ruby 2.7+.