### PR TITLE
New dsl method: lazy(&block)

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -108,6 +108,7 @@ module Rake
     # Run the top level tasks of a Rake application.
     def top_level
       run_with_threads do
+        execute_all_lazy_definitions if options.loadlazydefinitions
         if options.show_tasks
           display_tasks_and_comments
         elsif options.show_prereqs
@@ -499,6 +500,10 @@ module Rake
             "-N", "Do not search parent directories for the Rakefile.",
             lambda { |value| options.nosearch = true }
           ],
+          ["--load-lazy-definitions", "--loadlazydefinitions", 
+            "-L", "Include all lazy definitions when listing tasks with --tasks",
+            lambda { |value| options.loadlazydefinitions = true}
+          ],
           ["--prereqs", "-P",
             "Display the tasks and dependencies, then exit.",
             lambda { |value| options.show_prereqs = true }
@@ -807,6 +812,7 @@ module Rake
       options.job_stats                  = false
       options.load_system                = false
       options.nosearch                   = false
+      options.loadlazydefinitions        = false
       options.rakelib                    = %w[rakelib]
       options.show_all_tasks             = false
       options.show_prereqs               = false

--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -185,6 +185,12 @@ module Rake
         Rake.application.add_import(fn)
       end
     end
+
+    # Associate a block to the current scope and 
+    # execute it only when a lookup for a task is performed in the same scope.
+    def lazy(&block)
+      Rake.application.register_lazy_definition(&block)
+    end
   end
   extend FileUtilsExt
 end

--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -12,6 +12,7 @@ module Rake
       @rules = Array.new
       @scope = Scope.make
       @last_description = nil
+      @lazy_definitions = {}
     end
 
     def create_rule(*args, &block) # :nodoc:
@@ -208,6 +209,7 @@ module Rake
     def lookup_in_scope(name, scope)
       loop do
         tn = scope.path_with_task_name(name)
+        execute_lazy_definitions(tn.rpartition(':')[0])
         task = @tasks[tn]
         return task if task
         break if scope.empty?
@@ -233,6 +235,47 @@ module Rake
       ns
     ensure
       @scope = @scope.tail
+    end
+
+    # Execute all definitions: usefull for rake -T for instance
+    def execute_all_lazy_definitions
+      @lazy_definitions.each do |scope_path, _definitions|
+        execute_lazy_definitions(scope_path)
+      end
+    end
+
+    # Execute all definitions linked to specified +scope_path+
+    # and its parent scopes.
+    def execute_lazy_definitions(scope_path)
+      scope_path_elements = scope_path.split(':')
+      sub_scope_elements = []
+      scope_path_elements.each do |e|
+        sub_scope_elements << e
+        sub_scope_path = sub_scope_elements.join(':')
+        definitions = @lazy_definitions[sub_scope_path]
+        next unless definitions
+        definitions.each do |definition|
+          definition.call
+        end
+        definitions.clear
+      end
+    end
+
+    # Evaluate the block in specified +scope+.
+    def in_scope(scope)
+      cur_scope = @scope
+      @scope = scope
+      yield
+    ensure
+      @scope = cur_scope
+    end
+
+    # Register a block which will be called only when necessary during the lookup 
+    # of tasks
+    def register_lazy_definition(&block)
+      cur_scope = @scope
+      @lazy_definitions[cur_scope.path] ||= []
+      @lazy_definitions[cur_scope.path] << ->() { in_scope(cur_scope, &block) }
     end
 
     private

--- a/test/test_rake_dsl.rb
+++ b/test/test_rake_dsl.rb
@@ -38,4 +38,37 @@ class TestRakeDsl < Rake::TestCase # :nodoc:
     assert ! defined?(Commands), "should not define Commands"
   end
 
+  def test_lazy
+    call_count_t1 = 0
+    call_count_t3 = 0
+    namespace "a" do
+      lazy do
+        task "t1"
+        call_count_t1 += 1
+      end
+    end
+    namespace "b" do
+      task "t2"
+      namespace "c" do
+        lazy do
+          namespace "d" do
+            lazy do
+              task "t3"
+              call_count_t3 += 1
+            end
+          end
+        end
+      end
+    end
+    refute_nil Rake::Task["b:t2"]
+    assert_equal 0, call_count_t1
+    assert_equal 0, call_count_t3
+    refute_nil Rake::Task["a:t1"]
+    assert_equal 1, call_count_t1
+    assert_equal 0, call_count_t3
+    refute_nil Rake::Task["b:c:d:t3"]
+    assert_equal 1, call_count_t1
+    assert_equal 1, call_count_t3
+  end
+
 end

--- a/test/test_rake_task_manager.rb
+++ b/test/test_rake_task_manager.rb
@@ -186,4 +186,51 @@ class TestRakeTaskManager < Rake::TestCase # :nodoc:
     assert_equal ["next z"], values
   end
 
+  def test_lazy_definition  
+    t1, t2, t3 = nil, nil, nil
+    lazy_definition_call_count = 0
+    @tm.in_namespace("a1") do
+      @tm.register_lazy_definition do
+        t1 = @tm.define_task(Rake::Task, :t1)
+        lazy_definition_call_count += 1
+        @tm.in_namespace("a2") do
+          t2 = @tm.define_task(Rake::Task, :t2)
+        end
+      end
+    end
+    @tm.in_namespace("b") do
+      t3 = @tm.define_task(Rake::Task, :t3)
+    end
+    # task t3 is not lazy. It can be found
+    assert_equal t3, @tm[:t3, Rake::Scope.make("b")]
+    # lazy definition is not called until we look for task in namespace a
+    assert_equal lazy_definition_call_count, 0
+
+    # task t2 can be found
+    found_task_t2 = @tm[:t2, Rake::Scope.make("a1:a2")]
+    assert_equal t2, found_task_t2
+    # lazy definition is expected to be called
+    assert_equal lazy_definition_call_count, 1
+
+    # task t1 can also be found
+    found_task_t1 = @tm[:t1, Rake::Scope.make("a1")]
+    assert_equal t1, found_task_t1
+    # lazy definition is called at most once
+    assert_equal lazy_definition_call_count, 1
+  end
+
+  def test_execute_all_lazy_definitions
+    lazy_definition_call_count = 0
+    @tm.in_namespace("a") do
+      @tm.register_lazy_definition do
+        lazy_definition_call_count += 1
+      end
+    end
+    assert_equal lazy_definition_call_count, 0
+    @tm.execute_all_lazy_definitions
+    assert_equal lazy_definition_call_count, 1
+    @tm.execute_all_lazy_definitions
+    assert_equal lazy_definition_call_count, 1
+  end
+
 end


### PR DESCRIPTION
Make possible to lazy define tasks in a namespace. The tasks are
loaded only on lookup.

Lazy definitions can be executed on purpose when using the option
--load-lazy-definitions so that `rake --tasks --load-lazy-definitions`
list all tasks including the one defined in a lazy way.

Example of lazy definitions:
```
namespace 'a' do
  lazy { task 't' }
end
```
or
```
namespace 'a' do
  lazy { load 'namespace_a.rake' }
end
```