### PR TITLE
v10 use File.open  explicitly backport for CVE-2020-8130

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,9 @@
+=== 10.5.1 / 2020-03-04
+
+Enhancements:
+
+* Use File.open explicitly.
+
 === 10.5.0 / 2016-01-13
 
 Enhancements:

--- a/lib/rake.rb
+++ b/lib/rake.rb
@@ -21,7 +21,7 @@
 #++
 
 module Rake
-  VERSION = '10.5.0'
+  VERSION = '10.5.1'
 end
 
 require 'rake/version'

--- a/lib/rake/file_list.rb
+++ b/lib/rake/file_list.rb
@@ -290,7 +290,7 @@ module Rake
       matched = 0
       each do |fn|
         begin
-          open(fn, "r", *options) do |inf|
+          File.open(fn, "r", *options) do |inf|
             count = 0
             inf.each do |line|
               count += 1


### PR DESCRIPTION
Ruby advisory DB was updated (https://github.com/rubysec/ruby-advisory-db/commit/2dd2668e0155c33bb802088b93bdf5b25ae6e9e0) 
It causes bundle-audit to fail for older projects which are unable to update to newer versions of rake.