### PR TITLE
rule learns to accept Symbols as a prereq name

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -300,8 +300,8 @@ module Rake
         when /^\./
           source = task_name.sub(task_pattern, ext)
           source == ext ? task_name.ext(ext) : source
-        when String
-          ext
+        when String, Symbol
+          ext.to_s
         when Proc, Method
           if ext.arity == 1
             ext.call(task_name)

--- a/test/test_rake_rules.rb
+++ b/test/test_rake_rules.rb
@@ -80,6 +80,17 @@ class TestRakeRules < Rake::TestCase # :nodoc:
     assert_equal [OBJFILE], @runs
   end
 
+  def test_rule_prereqs_can_be_created_by_symbol
+    task :nonfile do |t|
+      @runs << t.name
+    end
+    rule ".o" => :nonfile do |t|
+      @runs << t.name
+    end
+    Task[OBJFILE].invoke
+    assert_equal ["nonfile", OBJFILE], @runs
+  end
+
   def test_plain_strings_as_dependents_refer_to_files
     create_file(SRCFILE)
     rule ".o" => SRCFILE do |t|


### PR DESCRIPTION
rules presently expect string names as their prereqs (among others:
Procs/Methods, RegExp patterns, or pathmap specs)

This adds the conventional ability for a prereq task to be specified
using a Symbol as is common with non-file-based tasks.

closes #349