### PR TITLE
Simplify default rake test loader

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -181,43 +181,8 @@ module Rake
       when :testrb
         "-S testrb"
       when :rake
-        "#{rake_include_arg} \"#{rake_loader}\""
+        "-r#{__dir__}/rake_test_loader"
       end
-    end
-
-    def rake_loader # :nodoc:
-      find_file("rake/rake_test_loader") or
-        fail "unable to find rake test loader"
-    end
-
-    def find_file(fn) # :nodoc:
-      $LOAD_PATH.each do |path|
-        file_path = File.join(path, "#{fn}.rb")
-        return file_path if File.exist? file_path
-      end
-      nil
-    end
-
-    def rake_include_arg # :nodoc:
-      spec = Gem.loaded_specs["rake"]
-      if spec.respond_to?(:default_gem?) && spec.default_gem?
-        ""
-      else
-        "-I\"#{rake_lib_dir}\""
-      end
-    end
-
-    def rake_lib_dir # :nodoc:
-      find_dir("rake") or
-        fail "unable to find rake lib"
-    end
-
-    def find_dir(fn) # :nodoc:
-      $LOAD_PATH.each do |path|
-        file_path = File.join(path, "#{fn}.rb")
-        return path if File.exist? file_path
-      end
-      nil
     end
 
   end

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -128,7 +128,7 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
       t.loader = :rake
     end
 
-    assert_match(/\A-I".*?" ".*?"\Z/, test_task.run_code)
+    assert_match(/\A-r.*?\Z/, test_task.run_code)
   ensure
     Gem.loaded_specs["rake"] = rake
   end


### PR DESCRIPTION
Unless I'm missing something, we can require `rake_test_loader` directly. It's also safer, because there's no chance of requiring the file of a different copy of `rake`, and faster.