### PR TITLE
Update broken links to rake articles from Avdi in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -82,13 +82,13 @@ Type "rake --help" for all available options.
 === Presentations and Articles about Rake
 
 * Avdi Grimm's rake series:
-  1. {Rake Basics}[http://devblog.avdi.org/2014/04/21/rake-part-1-basics/]
-  2. {Rake File Lists}[http://devblog.avdi.org/2014/04/22/rake-part-2-file-lists/]
-  3. {Rake Rules}[http://devblog.avdi.org/2014/04/23/rake-part-3-rules/]
-  4. {Rake Pathmap}[http://devblog.avdi.org/2014/04/24/rake-part-4-pathmap/]
-  5. {File Operations}[http://devblog.avdi.org/2014/04/25/rake-part-5-file-operations/]
-  6. {Clean and Clobber}[http://devblog.avdi.org/2014/04/28/rake-part-6-clean-and-clobber/]
-  7. {MultiTask}[http://devblog.avdi.org/2014/04/29/rake-part-7-multitask/]
+  1. {Rake Basics}[https://avdi.codes/rake-part-1-basics/]
+  2. {Rake File Lists}[https://avdi.codes/rake-part-2-file-lists-2/]
+  3. {Rake Rules}[https://avdi.codes/rake-part-3-rules/]
+  4. {Rake Pathmap}[https://avdi.codes/rake-part-4-pathmap/]
+  5. {File Operations}[https://avdi.codes/rake-part-5-file-operations/]
+  6. {Clean and Clobber}[https://avdi.codes/rake-part-6-clean-and-clobber/]
+  7. {MultiTask}[https://avdi.codes/rake-part-7-multitask/]
 * {Jim Weirich's 2003 RubyConf presentation}[http://web.archive.org/web/20140221123354/http://onestepback.org/articles/buildingwithrake/]
 * Martin Fowler's article on Rake: http://martinfowler.com/articles/rake.html
 


### PR DESCRIPTION
In the Readme the links to the Avdi Grimm's rake series articles (https://github.com/ruby/rake#label-Presentations+and+Articles+about+Rake) are currently broken. This PR simply updates the readme to include the valid links.