### PR TITLE
Fix rake test loader swallowing useful error information

### DIFF
--- a/lib/rake/rake_test_loader.rb
+++ b/lib/rake/rake_test_loader.rb
@@ -2,24 +2,23 @@
 
 # Load the test files from the command line.
 argv = ARGV.select do |argument|
-  begin
-    case argument
-    when /^-/ then
-      argument
-    when /\*/ then
-      FileList[argument].to_a.each do |file|
-        require File.expand_path file
-      end
-
-      false
-    else
-      require File.expand_path argument
-
-      false
+  case argument
+  when /^-/ then
+    argument
+  when /\*/ then
+    FileList[argument].to_a.each do |file|
+      require File.expand_path file
     end
-  rescue LoadError => e
-    raise unless e.path
-    abort "\nFile does not exist: #{e.path}\n\n"
+
+    false
+  else
+    path = File.expand_path argument
+
+    abort "\nFile does not exist: #{path}\n\n" unless File.exist?(path)
+
+    require path
+
+    false
   end
 end
 

--- a/test/test_rake_rake_test_loader.rb
+++ b/test/test_rake_rake_test_loader.rb
@@ -24,7 +24,7 @@ class TestRakeRakeTestLoader < Rake::TestCase # :nodoc:
     $:.replace orig_loaded_features
   end
 
-  def test_load_error_from_require
+  def test_load_error_from_missing_test_file
     out, err = capture_io do
       ARGV.replace %w[no_such_test_file.rb]
 
@@ -43,6 +43,24 @@ class TestRakeRakeTestLoader < Rake::TestCase # :nodoc:
        \n\n\Z/x
 
     assert_match expected, err
+  end
+
+  def test_load_error_raised_implicitly
+    File.write("error_test.rb", "require 'superkalifragilisticoespialidoso'")
+    out, err = capture_io do
+      ARGV.replace %w[error_test.rb]
+
+      exc = assert_raises(LoadError) do
+        load @loader
+      end
+      if RUBY_ENGINE == "jruby"
+        assert_equal "no such file to load -- superkalifragilisticoespialidoso", exc.message
+      else
+        assert_equal "cannot load such file -- superkalifragilisticoespialidoso", exc.message
+      end
+    end
+    assert_empty out
+    assert_empty err
   end
 
   def test_load_error_raised_explicitly


### PR DESCRIPTION
I got a bug report in bundler where the end user error being printed was like this:

```
$ bundle exec rake test

File does not exist: pry

rake aborted!
Command failed with status (1)
/home/deivid/Code/ruby/rake/exe/rake:27:in `<top (required)>'
/home/deivid/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
/home/deivid/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

This error is very unhelpful about what's going on.

After debugging, I found that rake was swallowing useful information about the error, and also incorrectly stating that a file named "pry" was missing.

This changeset should fix the problem and now `rake` gives more useful information:

```
$ bundle exec rake test
Traceback (most recent call last):
	11: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	10: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	 9: from /home/deivid/Code/ruby/rake/lib/rake/rake_test_loader.rb:5:in `<top (required)>'
	 8: from /home/deivid/Code/ruby/rake/lib/rake/rake_test_loader.rb:5:in `select'
	 7: from /home/deivid/Code/ruby/rake/lib/rake/rake_test_loader.rb:16:in `block in <top (required)>'
	 6: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	 5: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	 4: from /tmp/repro/test/vendor/bundle/ruby/2.7.0/gems/activerecord-import-1.0.7/test/jdbcmysql/import_test.rb:1:in `<top (required)>'
	 3: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	 2: from /home/deivid/.rbenv/versions/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	 1: from /tmp/repro/test/vendor/bundle/ruby/2.7.0/gems/activerecord-import-1.0.7/test/test_helper.rb:13:in `<top (required)>'
/tmp/repro/test/vendor/bundle/ruby/2.7.0/gems/activerecord-import-1.0.7/test/test_helper.rb:13:in `require': cannot load such file -- pry (LoadError)
rake aborted!
Command failed with status (1)
/home/deivid/Code/ruby/rake/exe/rake:27:in `<top (required)>'
/home/deivid/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
/home/deivid/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```