### PR TITLE
Fix breaking change of execution order on TestTask

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -181,7 +181,7 @@ module Rake
       when :testrb
         "-S testrb"
       when :rake
-        "-r#{__dir__}/rake_test_loader"
+        "#{__dir__}/rake_test_loader.rb"
       end
     end
 

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -128,7 +128,7 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
       t.loader = :rake
     end
 
-    assert_match(/\A-r.*?\Z/, test_task.run_code)
+    assert_includes test_task.run_code, "lib/rake/rake_test_loader.rb"
   ensure
     Gem.loaded_specs["rake"] = rake
   end


### PR DESCRIPTION
Due to #357, execution order on Rake 13.0.2 changes from Rake 13.0.1.

Example:
```ruby
Rake::TestTask do |t|
  t.test_files = [
    "test/a.rb",
    "test/b.rb",
  ]
end
```

On 13.0.2, Rake executes test/b.rb before test/a.rb because test/a.rb are loaded before rake_test_loader.rb.
rake_test_loader.rb executes the Ruby code in ARGV using Kernel.#require, but does not execute test/a.rb which is already loaded.

In addition, Rake 13.0.1 allows specifying test_files without .rb but 13.0.2 doesn't allows.
This commit also fixes this problem.
```ruby
Rake::TestTask do |t|
  t.test_files = [
    "test/setup",
    "test/a.rb",
  ]
end
```