### PR TITLE
Allow cleaning namespaces

### DIFF
--- a/lib/rake/name_space.rb
+++ b/lib/rake/name_space.rb
@@ -21,6 +21,10 @@ class Rake::NameSpace
     @task_manager.lookup(name, @scope)
   end
 
+  def path
+    @scope.path
+  end
+
   ##
   # The scope of the namespace (a LinkedList)
 
@@ -33,6 +37,22 @@ class Rake::NameSpace
 
   def tasks
     @task_manager.tasks_in_scope(@scope)
+  end
+
+  def namespaces
+    @task_manager.namespaces_in_scope(@scope)
+  end
+
+  def clear
+    namespaces.each do |ns|
+      @task_manager.remove_namespace(ns.path)
+    end
+  end
+
+  class << self
+    def [](namespace_name)
+      Rake.application.lookup_namespace(namespace_name)
+    end
   end
 
 end


### PR DESCRIPTION
Closes #58

This is still a WIP (needs tests and documentation).
I need to verify from core members if this is a correct approach and based on the feedback will update the PR. 

Consideration: when cleaning a namespace, should we clean also inner namespaces? Current implementation does so.

This PR will allow to do:
```ruby
namespace :n do
  task :t do
    puts 'work'
  end
end

Rake::Namespace['n'].clear
```