### PR TITLE
Preserve match_data in rules

### DIFF
--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -38,6 +38,10 @@ module Rake
     # will be skipped unless you reenable them.
     attr_reader :already_invoked
 
+    # MatchData object returned when matching the task name
+    # against the rule pattern.
+    attr_accessor :match_data
+
     # Return task name
     def to_s
       name

--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -152,10 +152,14 @@ module Rake
       fail Rake::RuleRecursionOverflowError,
         "Rule Recursion Too Deep" if level >= 16
       @rules.each do |pattern, args, extensions, order_only, block|
-        if pattern && pattern.match(task_name)
+        if pattern && (m = pattern.match(task_name))
           task = attempt_rule(task_name, pattern, args, extensions, block, level)
-          task | order_only unless order_only.nil?
-          return task if task
+
+          if task
+            task | order_only unless order_only.nil?
+            task.match_data = m
+            return task
+          end
         end
       end
       nil

--- a/test/test_rake_rules.rb
+++ b/test/test_rake_rules.rb
@@ -409,4 +409,13 @@ class TestRakeRules < Rake::TestCase # :nodoc:
     assert_equal [MINFILE], @runs
   end
 
+  def test_rule_match_data
+    rule(/^(?<timestamp>\d{14})_(?<migration_name>[a-z_]+)\.rb$/) do |t|
+      @runs << t.match_data[:timestamp]
+      @runs << t.match_data[:migration_name]
+    end
+    Task["20191015182958_create_users.rb"].invoke
+    assert_equal ["20191015182958", "create_users"], @runs
+  end
+
 end


### PR DESCRIPTION
Closes #141 

Example of usage (from the issue):
```ruby
rule /^members/(?<email>.*)/\d{2}-(?<step>\w+).timestamp$/ do |t|
  email = t.match_data[:email]
  step  = t.match_data[:step]
  # ...
end
```

cc/ @avdi 