### PR TITLE
Lazily load `set`

### DIFF
--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "set"
 
 require "rake/promise"
 
@@ -10,6 +9,7 @@ module Rake
     # Creates a ThreadPool object.  The +thread_count+ parameter is the size
     # of the pool.
     def initialize(thread_count)
+      require "set"
       @max_active_threads = [thread_count, 0].max
       @threads = Set.new
       @threads_mon = Monitor.new


### PR DESCRIPTION
This file seems required by `rake` by default. By lazily loading `set`, usages of `rake` that don't use this part of `rake`, don't unnecessarily activate the `set` gem.

This seems really minor, I know. But when testing rubygems & bundler, it's interesting for us to be in full control of the gems that are
loaded, to make sure that we don't unintentionally activate gems causing our users to be unable to select the version of those gems that they need.