### PR TITLE
Add safe invocation CLI syntax

### DIFF
--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -439,6 +439,26 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     assert_equal "DEFAULT\n", out
   end
 
+  def test_safe_run
+    ran = false
+
+    @app.options.silent = true
+
+    @app.instance_eval do
+      intern(Rake::Task, "default").enhance { ran = true }
+    end
+
+    rakefile_default
+
+    out, err = capture_io do
+      @app.run %w[--rakelib="" default missing?]
+    end
+
+    assert ran
+    assert_empty err
+    assert_equal "DEFAULT\n", out
+  end
+
   def test_display_task_run
     ran = false
     @app.last_description = "COMMENT"


### PR DESCRIPTION
Example: `rake may:or:maynot:exist?`

Such syntax is useful for projects like buildpacks and other automated CI/CD tools.

It would allow these tools to very easily invoke a taskif it exists, without failing if it doesn't.

@hsbt is this a feature that could be acceptable?

Also cc @schneems, since as maintainer of https://github.com/heroku/heroku-buildpack-ruby I suspect such feature could be useful.