### PR TITLE
Remove unnecessary require

### DIFF
--- a/lib/rake/rake_test_loader.rb
+++ b/lib/rake/rake_test_loader.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "rake"
 
 # Load the test files from the command line.
 argv = ARGV.select do |argument|


### PR DESCRIPTION
I don't think this require is necessary, and it causes issues if you use the default loader in combination with the `--disable-gems` flag. I guess this could potentially break something is somebody is using the `Rake` constant directly in their tests without requiring `rake`. That should be very rare and easily fixable by requiring it.