### PR TITLE
CI: use "3.0" to avoid YAML float conversions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby: [ 3.0, 2.7, 2.6, ruby-head ]
+        ruby: [ '3.0', 2.7, 2.6, ruby-head ]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        ruby: [ 3.0, 2.7, 2.6, ruby-head ]
+        ruby: [ '3.0', 2.7, 2.6, ruby-head ]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR uses the quoting from the test.yml in the other YAML files for CI.