### PR TITLE
(Performance) Remove unnecessary I/O syscalls for FileTasks

### DIFF
--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -19,9 +19,9 @@ module Rake
 
     # Time stamp for file task.
     def timestamp
-      if File.exist?(name)
-        File.mtime(name.to_s)
-      else
+      begin
+        File.mtime(name)
+      rescue Errno::ENOENT
         Rake::LATE
       end
     end

--- a/lib/rake/file_task.rb
+++ b/lib/rake/file_task.rb
@@ -14,7 +14,11 @@ module Rake
     # Is this file task needed?  Yes if it doesn't exist, or if its time stamp
     # is out of date.
     def needed?
-      !File.exist?(name) || out_of_date?(timestamp) || @application.options.build_all
+      begin
+        out_of_date?(File.mtime(name)) || @application.options.build_all
+      rescue Errno::ENOENT
+        true
+      end
     end
 
     # Time stamp for file task.


### PR DESCRIPTION
I’m assuming that no benchmarking will be required for the claim “fewer I/O syscall means better performance”.

This may only seem like a trivial improvement for smaller projects. However, I’m dealing with about 22 000 files, and removing <del>this one</del> <ins>these two</ins> system call<ins>s</ins> cut my no-changes build time by <del>14,8 %</del> <ins>12,4 %</ins> on a fast M.2 SSD. 