### PR TITLE
Apply RuboCop linting for Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,6 @@ AllCops:
     - rake.gemspec
     - bin/*
 
-Metrics/LineLength:
-  Enabled: true
-  Max: 120
-
 Style/HashSyntax:
   Enabled: true
 
@@ -23,8 +19,9 @@ Style/MultilineIfThen:
 Style/MethodDefParentheses:
   Enabled: true
 
-Style/BracesAroundHashParameters:
+Layout/LineLength:
   Enabled: true
+  Max: 120
 
 Layout/IndentationWidth:
   Enabled: true
@@ -35,7 +32,7 @@ Layout/Tab:
 Layout/EmptyLines:
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Layout/TrailingWhitespace:

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :development do
   gem "bundler"
   gem "minitest"
   gem "coveralls"
-  gem "rubocop"
+  gem "rubocop", "~> 0.81.0"
 end

--- a/lib/rake/task.rb
+++ b/lib/rake/task.rb
@@ -276,9 +276,9 @@ module Rake
       application.trace "** Execute #{name}" if application.options.trace
       application.enhance_with_matching_rule(name) if @actions.empty?
       if opts = Hash.try_convert(args) and !opts.empty?
-        @actions.each { |act| act.call(self, args, **opts)}
+        @actions.each { |act| act.call(self, args, **opts) }
       else
-        @actions.each { |act| act.call(self, args)}
+        @actions.each { |act| act.call(self, args) }
       end
     end
 

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -4,7 +4,7 @@ require "rake/clean"
 
 class TestRakeClean < Rake::TestCase # :nodoc:
   def test_clean
-    if RUBY_ENGINE == 'truffleruby' and RUBY_ENGINE_VERSION.start_with?('19.3.')
+    if RUBY_ENGINE == "truffleruby" and RUBY_ENGINE_VERSION.start_with?("19.3.")
       load "rake/clean.rb" # TruffleRuby 19.3 does not set self correctly with wrap=true
     else
       load "rake/clean.rb", true

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -496,7 +496,7 @@ class TestRakeFileList < Rake::TestCase # :nodoc:
     assert_equal ["a", "b", "c"], d
   end
 
-  if RUBY_VERSION < '2.7'
+  if RUBY_VERSION < "2.7"
     def test_dup_and_clone_replicate_taint
       a = FileList["a", "b", "c"]
       a.taint

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -126,7 +126,7 @@ class TestRakeTask < Rake::TestCase # :nodoc:
       next if !raise_exception
 
       raise_exception = false
-      raise 'Some error'
+      raise "Some error"
     end
 
     assert_raises(RuntimeError) { t1.invoke }

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -171,20 +171,20 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
   end
 
   def test_task_order_only_prerequisites
-    t = task(a: 'b') {
+    t = task(a: "b") {
       :aaa
-    } | 'c'
-    b, c = task('b'), task('c')
-    assert_equal ['b'], t.prerequisites
-    assert_equal ['c'], t.order_only_prerequisites
+    } | "c"
+    b, c = task("b"), task("c")
+    assert_equal ["b"], t.prerequisites
+    assert_equal ["c"], t.order_only_prerequisites
     assert_equal [b, c], t.prerequisite_tasks
   end
 
   def test_task_order_only_prerequisites_key
-    t = task 'a' => 'b', order_only: ['c']
-    b, c = task('b'), task('c')
-    assert_equal ['b'], t.prerequisites
-    assert_equal ['c'], t.order_only_prerequisites
+    t = task "a" => "b", order_only: ["c"]
+    b, c = task("b"), task("c")
+    assert_equal ["b"], t.prerequisites
+    assert_equal ["c"], t.order_only_prerequisites
     assert_equal [b, c], t.prerequisite_tasks
   end
 end


### PR DESCRIPTION
- Pin rubocop to 0.81.0 to keep [TargetRubyVersion: 2.3](https://github.com/ruby/rake/blob/881416e322d597e47e62935ef6a9dbaed934fbfc/.rubocop.yml#L2)
- Update `.rubocop.yml`:
  - Rename `Metrics/LineLength` to `Layout/LineLength` ([0.78.0](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0780-2019-12-18))
  - Remove `Style/BracesAroundHashParameters` cop` ([0.80.0](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0800-2020-02-18))
  - Rename `Layout/TrailingBlankLines` to `Layout/TrailingEmptyLines` (older version...)

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>