### PR TITLE
Update rubocop to work with Ruby 2.4 compatible

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisabledByDefault: true
+  SuggestExtensions: false
   Exclude:
     - doc/**/*.rb
     - rake.gemspec
@@ -26,7 +27,7 @@ Layout/LineLength:
 Layout/IndentationWidth:
   Enabled: true
 
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
 Layout/EmptyLines:

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :development do
   gem "bundler"
   gem "minitest"
   gem "coveralls"
-  gem "rubocop", "~> 0.81.0"
+  gem "rubocop", "~> 1.12.1"
 end


### PR DESCRIPTION
- Pin rubocop to 1.12.x to bump `TargetRubyVersion` from 2.3 to 2.4
- Update `.rubocop.yml` config
   - cf. https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0820-2020-04-16

Blocked by #423