### PR TITLE
Add RuboCop job to Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: true
+    - name: Run rubocop
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - doc/**/*.rb
     - rake.gemspec
     - bin/*
+    - vendor/**/*
 
 Style/HashSyntax:
   Enabled: true


### PR DESCRIPTION
Just to avoid drifts such as ones fixed in #423.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>