### PR TITLE
Eagerly require set in thread_pool.rb

### DIFF
--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rake/promise"
+require "set"
 
 module Rake
 
@@ -9,7 +10,6 @@ module Rake
     # Creates a ThreadPool object.  The +thread_count+ parameter is the size
     # of the pool.
     def initialize(thread_count)
-      require "set"
       @max_active_threads = [thread_count, 0].max
       @threads = Set.new
       @threads_mon = Monitor.new


### PR DESCRIPTION
Lazily requiring it in this matter can break rake whenever
a rake task limits access to the file system.  For example:

```ruby
task :default do
  Dir.chroot Dir.pwd
end
```

One reason to lazily require this is to save on memory, but
since Rake::Application appears to always use a thread pool
(Rake::Application#run -> top_level -> run_with_threads ->
thread_pool), it doesn't looks like lazily requiring actually
saves memory in this case.