### PR TITLE
Avoid creating an unnecessary thread pool

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -124,7 +124,7 @@ module Rake
 
       yield
 
-      thread_pool.join
+      thread_pool.join if defined?(@thread_pool)
       if options.job_stats
         stats = thread_pool.statistics
         puts "Maximum active threads: #{stats[:max_active_threads]} + main"


### PR DESCRIPTION
If the thread_pool does not already exist, there is no point in
creating a thread pool just to join the threads in it.

This is an alternative fix for #440.