### PR TITLE
Fix exception when exception has nil backtrace

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -215,7 +215,7 @@ module Rake
       display_exception_details_seen << ex
 
       display_exception_message_details(ex)
-      display_exception_backtrace(ex)
+      display_exception_backtrace(ex) if ex.backtrace
       display_cause_details(ex.cause) if has_cause?(ex)
     end
 


### PR DESCRIPTION
Fixing:
```
C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/backtrace.rb:21:in `collapse': undefined method `reject' for nil:NilClass (NoMethodError)

      backtrace.reject { |elem| elem =~ pattern }
               ^^^^^^^
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:249:in `display_exception_backtrace'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:218:in `display_exception_details'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:226:in `display_cause_details'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:219:in `display_exception_details'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:208:in `display_error_message'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:195:in `rescue in standard_exception_handling'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:185:in `standard_exception_handling'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/lib/rake/application.rb:80:in `run'
        from C:/Ruby32-x64/lib/ruby/gems/3.2.0+3/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
        from C:/Ruby32-x64/bin/rake:33:in `load'
        from C:/Ruby32-x64/bin/rake:33:in `<main>'
```