### PR TITLE
Add ruby 3.2 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
-        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, jruby, jruby-head, truffleruby, ruby-head ]
+        ruby: [ 3.2, 3.1, '3.0', 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, jruby, jruby-head, truffleruby, ruby-head ]
         exclude:
           - os: windows-latest
             ruby: truffleruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
             ruby: jruby
     steps:
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-    - uses: ruby/setup-ruby@03b78bdda287ae04217ee12e4b64996630a03542 # v1.131.0
+    - uses: ruby/setup-ruby@09c10210cc6e998d842ce8433cd9d245933cd797 # v1.133.0
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies


### PR DESCRIPTION
It was released just recently on december 25th and the test suite does not show
any needed changes, so it should be added to the test matrix.