### PR TITLE
Rewrite auto-merge feature for dependabot

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,42 +1,26 @@
 # from https://github.com/gofiber/swagger/blob/main/.github/workflows/dependabot_automerge.yml
 name: Dependabot auto-merge
 on:
-  pull_request
-
-permissions:
-  contents: write
-  pull-requests: write
+  pull_request_target:
 
 jobs:
-  wait_for_checks:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Wait for check is finished
-        uses: lewagon/wait-on-check-action@v1.2.0
-        id: wait_for_checks
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          running-workflow-name: wait_for_checks
-          check-regexp: test
-          wait-interval: 10
-        env:
-          REPO_TOKEN: ${{ secrets.MATZBOT_GITHUB_TOKEN }}
-  dependabot:
-    needs: [wait_for_checks]
-    name: Dependabot auto-merge
+  automerge:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
+        uses: dependabot/fetch-metadata@v1
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.6
+      - name: Wait for status checks
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          github-token: "${{ secrets.MATZBOT_GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: |
-            gh pr merge --auto --merge "$PR_URL"
+          repo-token: ${{ secrets.MATZBOT_GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          check-regexp: test*
+          wait-interval: 30
+      - name: Auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.MATZBOT_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.MATZBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
* Use `pull_request_target`
  * https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
* Apply single step.
* Removed needless feature.