### PR TITLE
Support `#detailed_message` when task failed

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -237,6 +237,8 @@ module Rake
     def display_exception_message_details(ex) # :nodoc:
       if ex.instance_of?(RuntimeError)
         trace ex.message
+      elsif ex.respond_to?(:detailed_message)
+        trace "#{ex.class.name}: #{ex.detailed_message(highlight: false)}"
       else
         trace "#{ex.class.name}: #{ex.message}"
       end

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -60,31 +60,29 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     assert_match __method__.to_s, err
   end
 
-  if Exception.method_defined?(:detailed_message)
-    def test_display_exception_details_with_detailed_message
-      error_class = Class.new(StandardError) do
-        def detailed_message(**)
-          "detailed_message!!"
-        end
+  def test_display_exception_details_with_detailed_message
+    error_class = Class.new(StandardError) do
+      def detailed_message(**)
+        "detailed_message!!"
       end
-
-      begin
-        raise error_class
-      rescue error_class => ex
-      end
-
-      out, err = capture_io do
-        @app.set_default_options # reset trace output IO
-
-        @app.display_error_message ex
-      end
-
-      assert_empty out
-
-      assert_match "rake aborted!", err
-      assert_match "detailed_message!!", err
-      assert_match __method__.to_s, err
     end
+
+    begin
+      raise error_class
+    rescue error_class => ex
+    end
+
+    out, err = capture_io do
+      @app.set_default_options # reset trace output IO
+
+      @app.display_error_message ex
+    end
+
+    assert_empty out
+
+    assert_match "rake aborted!", err
+    assert_match "detailed_message!!", err
+    assert_match __method__.to_s, err
   end
 
   def test_display_exception_details_bad_encoding

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -60,6 +60,33 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     assert_match __method__.to_s, err
   end
 
+  if Exception.method_defined?(:detailed_message)
+    def test_display_exception_details_with_detailed_message
+      error_class = Class.new(StandardError) do
+        def detailed_message(**)
+          "detailed_message!!"
+        end
+      end
+
+      begin
+        raise error_class
+      rescue error_class => ex
+      end
+
+      out, err = capture_io do
+        @app.set_default_options # reset trace output IO
+
+        @app.display_error_message ex
+      end
+
+      assert_empty out
+
+      assert_match "rake aborted!", err
+      assert_match "detailed_message!!", err
+      assert_match __method__.to_s, err
+    end
+  end
+
   def test_display_exception_details_bad_encoding
     begin
       raise "El Niño is coming!".dup.force_encoding("US-ASCII")


### PR DESCRIPTION
The `Exception#detailed_message` method was added in Ruby v3.2.0 and is used by the [error_highlight](https://github.com/ruby/error_highlight) gem and others.

https://bugs.ruby-lang.org/issues/18564

However, on the rake task, this benefit is not available due to the use of `Exception#message`.

I propose that the `detailed_message` method call if it can be called.

### use case

ruby v3.2.1

Rakefile

```
task :demo do
  p self.opject_id
end
```

before

```
$ bundle exec rake demo
rake aborted!
NoMethodError: undefined method `opject_id' for main:Object
/Users/ksss/src/github.com/ksss/rake/Rakefile:35:in `block in <top (required)>'
/Users/ksss/src/github.com/ksss/rake/exe/rake:27:in `<top (required)>'
/Users/ksss/.rbenv/versions/3.2.1/bin/bundle:25:in `load'
/Users/ksss/.rbenv/versions/3.2.1/bin/bundle:25:in `<main>'
Tasks: TOP => demo
(See full trace by running task with --trace)
```

after

```
$ bundle exec rake demo
rake aborted!
NoMethodError: undefined method `opject_id' for main:Object (NoMethodError)

  p self.opject_id
        ^^^^^^^^^^
Did you mean?  object_id
/Users/ksss/src/github.com/ksss/rake/Rakefile:35:in `block in <top (required)>'
/Users/ksss/src/github.com/ksss/rake/exe/rake:27:in `<top (required)>'
/Users/ksss/.rbenv/versions/3.2.1/bin/bundle:25:in `load'
/Users/ksss/.rbenv/versions/3.2.1/bin/bundle:25:in `<main>'
Tasks: TOP => demo
(See full trace by running task with --trace)
```