### PR TITLE
Debug at stop when task fail

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -94,7 +94,7 @@ module Rake
           # Backward compatibility for capistrano
           args = handle_options
         end
-        load_debug_at_stop
+        load_debug_at_stop_feature
         collect_command_line_tasks(args)
       end
     end
@@ -118,7 +118,7 @@ module Rake
       }
     rescue LoadError
     end
-    private :load_debug_at_stop
+    private :load_debug_at_stop_feature
 
     # Find the rakefile and then load it and any pending imports.
     def load_rakefile

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -101,7 +101,7 @@ module Rake
 
     def load_debug_at_stop_feature
       return unless ENV["RAKE_DEBUG"]
-      require 'debug/session'
+      require "debug/session"
       DEBUGGER__::start no_sigint_hook: true, nonstop: true
       Rake::Task.prepend Module.new {
         def execute(*)

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -100,7 +100,7 @@ module Rake
     end
 
     def load_debug_at_stop_feature
-      return unless ['1', 'true'].include?(ENV["RAKE_DEBUG"])
+      return unless ENV["RAKE_DEBUG"]
       require 'debug/session'
       DEBUGGER__::start no_sigint_hook: true, nonstop: true
       Rake::Task.prepend Module.new {

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -94,9 +94,31 @@ module Rake
           # Backward compatibility for capistrano
           args = handle_options
         end
+        load_debug_at_stop
         collect_command_line_tasks(args)
       end
     end
+
+    def load_debug_at_stop_feature
+      return unless ['1', 'true'].include?(ENV["RAKE_DEBUG"])
+      require 'debug/session'
+      DEBUGGER__::start no_sigint_hook: true, nonstop: true
+      Rake::Task.prepend Module.new {
+        def execute(*)
+          exception = DEBUGGER__::SESSION.capture_exception_frames(/(exe|bin|lib)\/rake/) do
+            super
+          end
+
+          if exception
+            STDERR.puts exception.message
+            DEBUGGER__::SESSION.enter_postmortem_session exception
+            raise exception
+          end
+        end
+      }
+    rescue LoadError
+    end
+    private :load_debug_at_stop
 
     # Find the rakefile and then load it and any pending imports.
     def load_rakefile


### PR DESCRIPTION
## Probrem

If the rake task terminates with some error, starting a postmortem session with the debug gem will start in the rescue block of `Rake::Application#standard_exception_handling`, making debugging is difficult.

Rakefile

```
task :demo do
  aaa
end
```

```
$ bundle exec rdbg -c -- rake demo
[4, 13] in ~/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bin/rake
     4| #
     5| # The application 'rake' is installed as part of a gem, and
     6| # this file is here to facilitate running it.
     7| #
     8|
=>   9| require 'rubygems'
    10|
    11| Gem.use_gemdeps
    12|
    13| version = ">= 0.a"
=>#0	<main> at ~/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bin/rake:9
(rdbg) config set postmortem true    # command
postmortem = true                  # CONTROL: Enable postmortem debug (default: false)
(rdbg) c    # continue command
rake aborted!
NameError: undefined local variable or method `aaa' for main:Object
/Users/ksss/src/github.com/ksss/rake/Rakefile:35:in `block in <top (required)>'
/Users/ksss/src/github.com/ksss/rake/exe/rake:27:in `<top (required)>'
Tasks: TOP => demo
(See full trace by running task with --trace)
Enter postmortem mode with #<NameError: undefined local variable or method `aaa' for main:Object>
  /Users/ksss/src/github.com/ksss/rake/Rakefile:35:in `block in <top (required)>'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/task.rb:281:in `block in execute'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/task.rb:281:in `each'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/task.rb:281:in `execute'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/task.rb:199:in `synchronize'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/task.rb:199:in `invoke_with_call_chain'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/task.rb:188:in `invoke'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:160:in `invoke_task'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:116:in `block (2 levels) in top_level'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:116:in `each'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:116:in `block in top_level'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:125:in `run_with_threads'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:110:in `top_level'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:83:in `block in run'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:186:in `standard_exception_handling'
  /Users/ksss/src/github.com/ksss/rake/lib/rake/application.rb:80:in `run'
  /Users/ksss/src/github.com/ksss/rake/exe/rake:27:in `<top (required)>'
  /Users/ksss/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bin/rake:25:in `load'
  /Users/ksss/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bin/rake:25:in `<main>'

[218, 227] in ~/src/github.com/ksss/rake/lib/rake/task.rb
   218|           invoke_prerequisites(task_args, new_chain)
   219|           execute(task_args) if needed?
   220|         rescue Exception => ex
   221|           add_chain_to(ex, new_chain)
   222|           @invocation_exception = ex
=> 223|           raise ex
   224|         end
   225|       end
   226|     end
   227|     protected :invoke_with_call_chain
=>#0	Rake::Task#invoke_with_call_chain at ~/src/github.com/ksss/rake/lib/rake/task.rb:223
  #1	block in invoke_with_call_chain at ~/src/github.com/ksss/rake/lib/rake/task.rb:200
  # and 15 frames (use `bt' command for all frames)
(rdbg:postmortem)
```

## Proposal

I propose to add a feature that will activate the debugger.
This feature will only work if the [debug](https://github.com/ruby/debug) gem is already loaded and the environment variable `RAKE_DEBUG=1` is attached.

```
$ RAKE_DEBUG=1 bundle exec rake demo
undefined local variable or method `aaa' for main:Object
[30, 36] in ~/src/github.com/ksss/rake/Rakefile
    30| end
    31|
    32| task default: :test
    33|
    34| task :demo do
=>  35|   aaa
    36| end
=>#0	block in <top (required)> at ~/src/github.com/ksss/rake/Rakefile:35
  #1	[C] Kernel.load at ~/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/cli/exec.rb:58
  # and 14 frames (use `bt' command for all frames)
(rdbg:postmortem)
```

Inspired by https://github.com/ko1/rspec-debug