### PR TITLE
Fix broken links on ruby.github.io/rake home page

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,4 +29,15 @@ RDoc::Task.new do |doc|
   doc.rdoc_dir = "_site" # for github pages
 end
 
+namespace :rdoc do
+  task :fix_links do
+    %w[_site/index.html _site/README_rdoc.html].each do |path|
+      fixed = File.read(path).gsub(%r{href="(doc/[^"]+?)\.rdoc"}, 'href="\1_rdoc.html"')
+      File.write(path, fixed)
+    end
+  end
+end
+
+task rdoc: ["rdoc:fix_links"]
+
 task default: :test


### PR DESCRIPTION
The homepage for Rake (https://ruby.github.io/rake/) has 4 broken links in the **Rake Information** section. Clicking them takes the user to a 404 page. The links point to `.rdoc` files that are transformed to `_rdoc.html` in the generated site. The links reference the original `.rdoc` names, so they don't work.

The links work when rendered on GitHub, however.

Ultimately the problem is that GitHub and rdoc generate these links differently. If the link is declared with the `link:` prefix (as they currently are), they work on GitHub, but break in the rendered rdoc site. On the other hand, if the `link:` prefix is removed, they work in the rdoc site but break on GitHub.

This commit applies a workaround to fix this. The source files are unchanged, but an additional build step has been added to the `rdoc` Rake task: after the site is generated, the broken links are detected and rewritten to have the correct names.

Because the source files have not been changed, the GitHub rendering will continue to work. This commit only affects the generated rdoc output, in order to fix the links.