### PR TITLE
Pattern matching support for arguments

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -94,6 +94,10 @@ module Rake
       @hash.fetch(*args, &block)
     end
 
+    def deconstruct_keys(keys)
+      @hash.slice(*keys)
+    end
+
     protected
 
     def lookup(name) # :nodoc:

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -54,6 +54,13 @@ class TestRakeTaskArguments < Rake::TestCase # :nodoc:
     assert_equal 0,  h.fetch(:one)
   end
 
+  def test_deconstruct_keys
+    omit "No stable pattern matching until Ruby 3.1 (testing #{RUBY_VERSION})" if RUBY_VERSION < "3.1"
+
+    ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])
+    assert_equal ta.deconstruct_keys([:a, :b]), { a: 1, b: 2 }
+  end
+
   def test_enumerable_behavior
     ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])
     assert_equal [10, 20, 30], ta.map { |k, v| v * 10 }.sort


### PR DESCRIPTION
Implement `Rake::TaskArguments#deconstruct_keys`. This means in an idiomatic ruby 3.x rake task we can use rightward assignment to say:

```
task :get, %i[tenant id] do |_t, args|
  args => {tenant:, id:}
  ...
end
```

... and omit the `.to_h` from `args`, raising `NoMatchingPatternError` if either of the two params is absent from the task args.