### PR TITLE
Fix rule example to be correct

### DIFF
--- a/lib/rake/dsl_definition.rb
+++ b/lib/rake/dsl_definition.rb
@@ -145,7 +145,7 @@ module Rake
     #
     # Example:
     #  rule '.o' => '.c' do |t|
-    #    sh 'cc', '-o', t.name, t.source
+    #    sh 'cc', '-c', '-o', t.name, t.source
     #  end
     #
     def rule(*args, &block) # :doc:


### PR DESCRIPTION
.c -> .o requires the -c flag. This could be confusing.
