### PR TITLE
Switch to use test-unit

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         ruby-version: '3.0'
     - name: Install dependencies
-      run: gem install test-unit
+      run: gem install test-unit coveralls
     - name: Run test
       env:
         COVERALLS: "yes"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         ruby-version: '3.0'
     - name: Install dependencies
-      run: gem install minitest -v "5.15.0"
+      run: gem install test-unit
     - name: Run test
       env:
         COVERALLS: "yes"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
-      run: gem install minitest -v "5.15.0"
+      run: gem install test-unit
     - name: Run test
       run: ruby -Ilib exe/rake

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
-  gem "minitest"
+  gem "test-unit"
   gem "coveralls"
   gem "rubocop"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,8 +10,7 @@ begin
 rescue Gem::LoadError
 end
 
-gem "minitest", "~> 5"
-require "minitest/autorun"
+require "test/unit"
 require "rake"
 require "tmpdir"
 
@@ -19,7 +18,7 @@ require_relative "support/file_creation"
 require_relative "support/ruby_runner"
 require_relative "support/rakefile_definitions"
 
-class Rake::TestCase < Minitest::Test
+class Rake::TestCase < Test::Unit::TestCase
   include FileCreation
 
   include Rake::DSL

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -48,7 +48,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     rescue => ex
     end
 
-    out, err = capture_io do
+    out, err = capture_output do
       @app.set_default_options # reset trace output IO
 
       @app.display_error_message ex
@@ -72,7 +72,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     rescue error_class => ex
     end
 
-    out, err = capture_io do
+    out, err = capture_output do
       @app.set_default_options # reset trace output IO
 
       @app.display_error_message ex
@@ -91,7 +91,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     rescue => ex
     end
 
-    out, err = capture_io do
+    out, err = capture_output do
       @app.set_default_options # reset trace output IO
 
       @app.display_error_message ex
@@ -111,7 +111,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
       end
     end
 
-    out, err = capture_io do
+    out, err = capture_output do
       @app.set_default_options # reset trace output IO
 
       @app.display_error_message ex
@@ -129,7 +129,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.options.show_task_pattern = //
     @app.last_description = "COMMENT"
     @app.define_task(Rake::Task, "t")
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
     assert_match(/^rake t/, out)
     assert_match(/# COMMENT/, out)
   end
@@ -142,7 +142,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.last_description = numbers
     @app.define_task(Rake::Task, "t")
 
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
 
     assert_match(/^rake t/, out)
     assert_match(/# #{numbers[0, 65]}\.\.\./, out)
@@ -156,7 +156,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.last_description = "something short"
     @app.define_task(Rake::Task, task_name)
 
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
 
     # Ensure the entire task name is output and we end up showing no description
     assert_match(/rake #{task_name}  # .../, out)
@@ -171,7 +171,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.last_description = "something short"
     @app.define_task(Rake::Task, task_name)
 
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
 
     # Ensure the entire task name is output and we end up showing no description
     assert_match(/rake #{task_name}  # #{description}/, out)
@@ -183,7 +183,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.tty_output = false
     @app.last_description = "1234567890" * 8
     @app.define_task(Rake::Task, "t")
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
     assert_match(/^rake t/, out)
     assert_match(/# #{@app.last_description}/, out)
   end
@@ -197,7 +197,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.last_description = numbers
     @app.define_task(Rake::Task, "t")
 
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
 
     assert_match(/^rake t/, out)
     assert_match(/# #{numbers[0, 65]}\.\.\./, out)
@@ -208,7 +208,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.options.show_task_pattern = //
     @app.last_description = "COMMENT"
     @app.define_task(Rake::Task, "t")
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
     assert_match(/^rake t$/, out)
     assert_match(/^ {4}COMMENT$/, out)
   end
@@ -219,7 +219,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.last_description = "COMMENT"
     @app.define_task(Rake::Task, "t")
     @app["t"].locations << "HERE:1"
-    out, = capture_io do @app.instance_eval { display_tasks_and_comments } end
+    out, = capture_output do @app.instance_eval { display_tasks_and_comments } end
     assert_match(/^rake t +[^:]+:\d+ *$/, out)
   end
 
@@ -251,7 +251,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
   def test_load_rakefile_doesnt_print_rakefile_directory_from_same_dir
     rakefile_unittest
 
-    _, err = capture_io do
+    _, err = capture_output do
       @app.instance_eval do
         # pretend we started from the unittest dir
         @original_dir = File.expand_path(".")
@@ -283,7 +283,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     app = Rake::Application.new
     app.options.rakelib = []
 
-    _, err = capture_io do
+    _, err = capture_output do
       app.instance_eval do
         raw_load_rakefile
       end
@@ -296,7 +296,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     rakefile_unittest
     Dir.chdir "subdir"
 
-    _, err = capture_io do
+    _, err = capture_output do
       @app.instance_eval do
         handle_options []
         options.silent = true
@@ -455,7 +455,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
 
     rakefile_default
 
-    out, err = capture_io do
+    out, err = capture_output do
       @app.run %w[--rakelib=""]
     end
 
@@ -468,7 +468,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     ran = false
     @app.last_description = "COMMENT"
     @app.define_task(Rake::Task, "default")
-    out, = capture_io { @app.run %w[-f -s --tasks --rakelib=""] }
+    out, = capture_output { @app.run %w[-f -s --tasks --rakelib=""] }
     assert @app.options.show_tasks
     assert ! ran
     assert_match(/rake default/, out)
@@ -482,7 +482,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     t.enhance([:a, :b])
     @app.define_task(Rake::Task, "a")
     @app.define_task(Rake::Task, "b")
-    out, = capture_io { @app.run %w[-f -s --prereqs --rakelib=""] }
+    out, = capture_output { @app.run %w[-f -s --prereqs --rakelib=""] }
     assert @app.options.show_prereqs
     assert ! ran
     assert_match(/rake a$/, out)
@@ -492,7 +492,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
 
   def test_bad_run
     @app.intern(Rake::Task, "default").enhance { fail }
-    _, err = capture_io {
+    _, err = capture_output {
       assert_raises(SystemExit) { @app.run %w[-f -s --rakelib=""] }
     }
     assert_match(/see full trace/i, err)
@@ -500,7 +500,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
 
   def test_bad_run_with_trace
     @app.intern(Rake::Task, "default").enhance { fail }
-    _, err = capture_io {
+    _, err = capture_output {
       @app.set_default_options
       assert_raises(SystemExit) { @app.run %w[-f -s -t] }
     }
@@ -509,7 +509,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
 
   def test_bad_run_with_backtrace
     @app.intern(Rake::Task, "default").enhance { fail }
-    _, err = capture_io {
+    _, err = capture_output {
       assert_raises(SystemExit) {
         @app.run %w[-f -s --backtrace]
       }
@@ -523,7 +523,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.intern(Rake::Task, "default").enhance {
       raise CustomError, "intentional"
     }
-    _, err = capture_io {
+    _, err = capture_output {
       assert_raises(SystemExit) {
         @app.run %w[-f -s]
       }
@@ -535,7 +535,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     @app.intern(Rake::Task, "default").enhance {
       fail "intentional"
     }
-    _, err = capture_io {
+    _, err = capture_output {
       assert_raises(SystemExit) {
         @app.run %w[-f -s]
       }
@@ -558,7 +558,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
         raise custom_error, "Secondary Error"
       end
     }
-    _ ,err = capture_io {
+    _ ,err = capture_output {
       assert_raises(SystemExit) {
         @app.run %w[-f -s]
       }
@@ -572,12 +572,12 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
   def test_run_with_bad_options
     @app.intern(Rake::Task, "default").enhance { fail }
     assert_raises(SystemExit) {
-      capture_io { @app.run %w[-f -s --xyzzy] }
+      capture_output { @app.run %w[-f -s --xyzzy] }
     }
   end
 
   def test_standard_exception_handling_invalid_option
-    out, err = capture_io do
+    out, err = capture_output do
       e = assert_raises SystemExit do
         @app.standard_exception_handling do
           raise OptionParser::InvalidOption, "blah"
@@ -592,7 +592,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
   end
 
   def test_standard_exception_handling_other
-    out, err = capture_io do
+    out, err = capture_output do
       @app.set_default_options # reset trace output IO
 
       e = assert_raises SystemExit do
@@ -610,7 +610,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
   end
 
   def test_standard_exception_handling_system_exit
-    out, err = capture_io do
+    out, err = capture_output do
       e = assert_raises SystemExit do
         @app.standard_exception_handling do
           exit 0
@@ -625,7 +625,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
   end
 
   def test_standard_exception_handling_system_exit_nonzero
-    out, err = capture_io do
+    out, err = capture_output do
       e = assert_raises SystemExit do
         @app.standard_exception_handling do
           exit 5

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -308,7 +308,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
   end
 
   def test_load_rakefile_not_found
-    skip if jruby9?
+    omit if jruby9?
 
     Dir.chdir @tempdir
     ENV["RAKE_SYSTEM"] = "not_exist"

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -107,7 +107,7 @@ class TestRakeApplicationOptions < Rake::TestCase # :nodoc:
 
   def test_execute_and_print
     $xyzzy = 0
-    out, = capture_io do
+    out, = capture_output do
       flags('--execute-print=$xyzzy="pugh"', '-p $xyzzy="pugh"') do
         assert_equal "pugh", $xyzzy
         assert_equal :exit, @exit
@@ -119,7 +119,7 @@ class TestRakeApplicationOptions < Rake::TestCase # :nodoc:
   end
 
   def test_help
-    out, = capture_io do
+    out, = capture_output do
       flags "--help", "-H", "-h"
     end
 
@@ -386,7 +386,7 @@ class TestRakeApplicationOptions < Rake::TestCase # :nodoc:
   end
 
   def test_verbose
-    capture_io do
+    capture_output do
       flags("--verbose", "-v") do |opts|
         assert Rake::FileUtilsExt.verbose_flag, "verbose should be true"
         assert ! opts.silent, "opts should not be silent"
@@ -395,7 +395,7 @@ class TestRakeApplicationOptions < Rake::TestCase # :nodoc:
   end
 
   def test_version
-    out, _ = capture_io do
+    out, _ = capture_output do
       flags "--version", "-V"
     end
 
@@ -405,7 +405,7 @@ class TestRakeApplicationOptions < Rake::TestCase # :nodoc:
   end
 
   def test_bad_option
-    _, err = capture_io do
+    _, err = capture_output do
       ex = assert_raises(OptionParser::InvalidOption) do
         flags("--bad-option")
       end

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -200,7 +200,7 @@ class TestRakeApplicationOptions < Rake::TestCase # :nodoc:
   end
 
   def test_missing_require
-    skip if jruby?
+    omit if jruby?
 
     ex = assert_raises(LoadError) do
       flags(["--require", "test/missing"]) do |opts|

--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -40,7 +40,7 @@ class TestRakeBacktrace < Rake::TestCase # :nodoc:
   def setup
     super
 
-    skip "tmpdir is suppressed in backtrace" if
+    omit "tmpdir is suppressed in backtrace" if
       Rake::Backtrace::SUPPRESS_PATTERN =~ Dir.pwd
   end
 

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -19,7 +19,7 @@ class TestRakeClean < Rake::TestCase # :nodoc:
   def test_cleanup
     file_name = create_undeletable_file
 
-    out, _ = capture_io do
+    out, _ = capture_output do
       Rake::Cleaner.cleanup(file_name, verbose: false)
     end
     assert_match(/failed to remove/i, out)
@@ -31,7 +31,7 @@ class TestRakeClean < Rake::TestCase # :nodoc:
   def test_cleanup_ignores_missing_files
     file_name = File.join(@tempdir, "missing_directory", "no_such_file")
 
-    out, _ = capture_io do
+    out, _ = capture_output do
       Rake::Cleaner.cleanup(file_name, verbose: false)
     end
     refute_match(/failed to remove/i, out)
@@ -40,7 +40,7 @@ class TestRakeClean < Rake::TestCase # :nodoc:
   def test_cleanup_trace
     file_name = create_file
 
-    out, err = capture_io do
+    out, err = capture_output do
       with_trace true do
         Rake::Cleaner.cleanup(file_name)
       end
@@ -79,7 +79,7 @@ class TestRakeClean < Rake::TestCase # :nodoc:
   def test_cleanup_opt_overrides_trace_verbose
     file_name = create_file
 
-    out, err = capture_io do
+    out, err = capture_output do
       with_trace false do
         Rake::Cleaner.cleanup(file_name, verbose: true)
       end
@@ -132,7 +132,7 @@ class TestRakeClean < Rake::TestCase # :nodoc:
     old, Rake.application.options.trace =
       Rake.application.options.trace, value
 
-    # FileUtils caches the $stderr object, which breaks capture_io et. al.
+    # FileUtils caches the $stderr object, which breaks capture_output et. al.
     # We hack it here where it's convenient to do so.
     Rake::Cleaner.instance_variable_set :@fileutils_output, nil
     yield

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -59,21 +59,25 @@ class TestRakeClean < Rake::TestCase # :nodoc:
   def test_cleanup_without_trace
     file_name = create_file
 
-    assert_output "", "" do
+    out, err = capture_output do
       with_trace false do
         Rake::Cleaner.cleanup(file_name)
       end
     end
+    assert_empty out
+    assert_empty err
   end
 
   def test_cleanup_opt_overrides_trace_silent
     file_name = create_file
 
-    assert_output "", "" do
+    out, err = capture_output do
       with_trace true do
         Rake::Cleaner.cleanup(file_name, verbose: false)
       end
     end
+    assert_empty out
+    assert_empty err
   end
 
   def test_cleanup_opt_overrides_trace_verbose

--- a/test/test_rake_clean.rb
+++ b/test/test_rake_clean.rb
@@ -119,7 +119,7 @@ class TestRakeClean < Rake::TestCase # :nodoc:
     rescue
       file_name
     else
-      skip "Permission to delete files is different on this system"
+      omit "Permission to delete files is different on this system"
     end
   end
 

--- a/test/test_rake_cpu_counter.rb
+++ b/test/test_rake_cpu_counter.rb
@@ -11,7 +11,7 @@ class TestRakeCpuCounter < Rake::TestCase # :nodoc:
 
   def test_count
     num = @cpu_counter.count
-    skip "cannot count CPU" if num == nil
+    omit "cannot count CPU" if num == nil
     assert_kind_of Numeric, num
     assert_operator num, :>=, 1
   end

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -383,7 +383,7 @@ class TestRakeFileList < Rake::TestCase # :nodoc:
   def test_egrep_with_output
     files = FileList["*.txt"]
 
-    out, = capture_io do
+    out, = capture_output do
       files.egrep(/XYZZY/)
     end
 
@@ -404,7 +404,7 @@ class TestRakeFileList < Rake::TestCase # :nodoc:
   def test_egrep_with_error
     files = FileList["*.txt"]
 
-    _, err = capture_io do
+    _, err = capture_output do
       files.egrep(/XYZZY/) do |fn, ln, line |
         raise "_EGREP_FAILURE_"
       end

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -519,7 +519,8 @@ class TestRakeFileList < Rake::TestCase # :nodoc:
     a = FileList["a", "b", "c"]
     a.freeze
     c = a.clone
-    assert_raises(TypeError, RuntimeError) do
+    error_class = defined?(FrozenError) ? FrozenError : RuntimeError
+    assert_raises(error_class) do
       c << "more"
     end
   end

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -350,30 +350,32 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   # https://github.com/seattlerb/minitest/blob/21d9e804b63c619f602f3f4ece6c71b48974707a/lib/minitest/assertions.rb#L546
   def capture_subprocess_io
     _synchronize do
-      require "tempfile"
+      begin
+        require "tempfile"
 
-      captured_stdout = Tempfile.new("out")
-      captured_stderr = Tempfile.new("err")
+        captured_stdout = Tempfile.new("out")
+        captured_stderr = Tempfile.new("err")
 
-      orig_stdout = $stdout.dup
-      orig_stderr = $stderr.dup
-      $stdout.reopen captured_stdout
-      $stderr.reopen captured_stderr
+        orig_stdout = $stdout.dup
+        orig_stderr = $stderr.dup
+        $stdout.reopen captured_stdout
+        $stderr.reopen captured_stderr
 
-      yield
+        yield
 
-      $stdout.rewind
-      $stderr.rewind
+        $stdout.rewind
+        $stderr.rewind
 
-      return captured_stdout.read, captured_stderr.read
-    ensure
-      $stdout.reopen orig_stdout
-      $stderr.reopen orig_stderr
+        return captured_stdout.read, captured_stderr.read
+      ensure
+        $stdout.reopen orig_stdout
+        $stderr.reopen orig_stderr
 
-      orig_stdout.close
-      orig_stderr.close
-      captured_stdout.close!
-      captured_stderr.close!
+        orig_stdout.close
+        orig_stderr.close
+        captured_stdout.close!
+        captured_stderr.close!
+      end
     end
   end
 

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -129,7 +129,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   def test_file_utils_methods_are_available_at_top_level
     create_file("a")
 
-    capture_io do
+    capture_output do
       rm_rf "a"
     end
 
@@ -256,7 +256,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   def test_sh_verbose
     shellcommand
 
-    _, err = capture_io do
+    _, err = capture_output do
       verbose(true) {
         sh %{shellcommand.rb}, noop: true
       }
@@ -268,7 +268,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   def test_sh_verbose_false
     shellcommand
 
-    _, err = capture_io do
+    _, err = capture_output do
       verbose(false) {
         sh %{shellcommand.rb}, noop: true
       }

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -282,9 +282,10 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
 
     RakeFileUtils.verbose_flag = nil
 
-    assert_silent do
+    out, _ = capture_output do
       sh %{shellcommand.rb}, noop: true
     end
+    assert_empty out
   end
 
   def test_ruby_with_a_single_string_argument

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -171,7 +171,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def test_sh_with_multiple_arguments
-    skip if jruby9? # https://github.com/jruby/jruby/issues/3653
+    omit if jruby9? # https://github.com/jruby/jruby/issues/3653
 
     check_no_expansion
     ENV["RAKE_TEST_SH"] = "someval"
@@ -182,7 +182,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def test_sh_with_spawn_options
-    skip "JRuby does not support spawn options" if jruby?
+    omit "JRuby does not support spawn options" if jruby?
 
     echocommand
 
@@ -198,7 +198,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def test_sh_with_hash_option
-    skip "JRuby does not support spawn options" if jruby?
+    omit "JRuby does not support spawn options" if jruby?
     check_expansion
 
     verbose(false) {
@@ -243,7 +243,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   def test_sh_bad_option
     # Skip on JRuby because option checking is performed by spawn via system
     # now.
-    skip "JRuby does not support spawn options" if jruby?
+    omit "JRuby does not support spawn options" if jruby?
 
     shellcommand
 
@@ -395,7 +395,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def test_ruby_with_multiple_arguments
-    skip if jruby9? # https://github.com/jruby/jruby/issues/3653
+    omit if jruby9? # https://github.com/jruby/jruby/issues/3653
 
     check_no_expansion
 

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -442,7 +442,7 @@ class TestRakeFunctional < Rake::TestCase # :nodoc:
 
     rake "-T"
 
-    refute_match("t2", @out)
+    refute_match(/t2/, @out)
   end
 
   def test_comment_after_desc_is_ignored

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -123,7 +123,7 @@ class TestRakeFunctional < Rake::TestCase # :nodoc:
   end
 
   def test_implicit_system
-    skip if jruby9?
+    omit if jruby9?
 
     rake_system_dir
     Dir.chdir @tempdir
@@ -470,7 +470,7 @@ class TestRakeFunctional < Rake::TestCase # :nodoc:
   end
 
   def test_file_list_is_requirable_separately
-    skip if jruby9? # https://github.com/jruby/jruby/issues/3655
+    omit if jruby9? # https://github.com/jruby/jruby/issues/3655
 
     ruby "-rrake/file_list", "-e", 'puts Rake::FileList["a"].size'
     assert_equal "1\n", @out
@@ -496,12 +496,12 @@ class TestRakeFunctional < Rake::TestCase # :nodoc:
       assert_match(/ATEST/, @out)
       refute_match(/BTEST/, @out)
     else
-      skip "Signal detect seems broken on this system"
+      omit "Signal detect seems broken on this system"
     end
   end
 
   def test_failing_test_sets_exit_status
-    skip if uncertain_exit_status?
+    omit if uncertain_exit_status?
     rakefile_failing_test_task
     rake
     assert @exit.exitstatus > 0, "should be non-zero"
@@ -520,7 +520,7 @@ class TestRakeFunctional < Rake::TestCase # :nodoc:
 
   # We are unable to accurately verify that Rake returns a proper
   # error exit status using popen3 in Ruby 1.8.7 and JRuby. This
-  # predicate function can be used to skip tests or assertions as
+  # predicate function can be used to omit tests or assertions as
   # needed.
   def uncertain_exit_status?
     defined?(JRUBY_VERSION)

--- a/test/test_rake_rake_test_loader.rb
+++ b/test/test_rake_rake_test_loader.rb
@@ -25,7 +25,7 @@ class TestRakeRakeTestLoader < Rake::TestCase # :nodoc:
   end
 
   def test_load_error_from_missing_test_file
-    out, err = capture_io do
+    out, err = capture_output do
       ARGV.replace %w[no_such_test_file.rb]
 
       assert_raises SystemExit do
@@ -47,7 +47,7 @@ class TestRakeRakeTestLoader < Rake::TestCase # :nodoc:
 
   def test_load_error_raised_implicitly
     File.write("error_test.rb", "require 'superkalifragilisticoespialidoso'")
-    out, err = capture_io do
+    out, err = capture_output do
       ARGV.replace %w[error_test.rb]
 
       exc = assert_raises(LoadError) do
@@ -65,7 +65,7 @@ class TestRakeRakeTestLoader < Rake::TestCase # :nodoc:
 
   def test_load_error_raised_explicitly
     File.write("error_test.rb", "raise LoadError, 'explicitly raised'")
-    out, err = capture_io do
+    out, err = capture_output do
       ARGV.replace %w[error_test.rb]
 
       exc = assert_raises(LoadError) do

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -64,7 +64,7 @@ class TestRakeTask < Rake::TestCase # :nodoc:
   def test_dry_run_prevents_actions
     runlist = []
     t1 = task(:t1) { |t| runlist << t.name; 3321 }
-    _, err = capture_io {
+    _, err = capture_output {
       Rake.application.set_default_options # reset trace output IO
       Rake.application.options.dryrun = true
 
@@ -80,7 +80,7 @@ class TestRakeTask < Rake::TestCase # :nodoc:
 
   def test_tasks_can_be_traced
     t1 = task(:t1)
-    _, err = capture_io {
+    _, err = capture_output {
       Rake.application.set_default_options # reset trace output IO
       Rake.application.options.trace = true
 

--- a/test/test_rake_task_with_arguments.rb
+++ b/test/test_rake_task_with_arguments.rb
@@ -83,7 +83,7 @@ class TestRakeTaskWithArguments < Rake::TestCase # :nodoc:
 
   def test_actions_adore_keywords
     # https://github.com/ruby/rake/pull/174#issuecomment-263460761
-    skip if jruby9?
+    omit if jruby9?
     eval <<-RUBY, binding, __FILE__, __LINE__+1
     notes = []
     t = task :t, [:reqr, :ovrd, :dflt] # required, overridden-optional, default-optional

--- a/test/test_rake_top_level_functions.rb
+++ b/test/test_rake_top_level_functions.rb
@@ -46,7 +46,7 @@ class TestRakeTopLevelFunctions < Rake::TestCase # :nodoc:
   end
 
   def test_when_writing
-    out, = capture_io do
+    out, = capture_output do
       when_writing("NOTWRITING") do
         puts "WRITING"
       end
@@ -56,7 +56,7 @@ class TestRakeTopLevelFunctions < Rake::TestCase # :nodoc:
 
   def test_when_not_writing
     Rake::FileUtilsExt.nowrite_flag = true
-    _, err = capture_io do
+    _, err = capture_output do
       when_writing("NOTWRITING") do
         puts "WRITING"
       end

--- a/test/test_rake_win32.rb
+++ b/test/test_rake_win32.rb
@@ -65,7 +65,7 @@ class TestRakeWin32 < Rake::TestCase # :nodoc:
     rake.options.trace = true
     rake.instance_variable_set(:@rakefile, "Rakefile")
 
-    _, err = capture_io {
+    _, err = capture_output {
       rake.set_default_options # reset trace output IO
 
       rake.display_error_message(ex)

--- a/test/test_thread_history_display.rb
+++ b/test/test_thread_history_display.rb
@@ -12,7 +12,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
   end
 
   def test_banner
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(/Job History/i, out)
@@ -20,7 +20,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
 
   def test_item_queued
     @stats << event(:item_queued,  item_id: 123)
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(/^ *1000000 +A +item_queued +item_id:1$/, out)
@@ -28,7 +28,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
 
   def test_item_dequeued
     @stats << event(:item_dequeued,  item_id: 123)
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(/^ *1000000 +A +item_dequeued +item_id:1$/, out)
@@ -37,7 +37,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
   def test_multiple_items
     @stats << event(:item_queued,  item_id: 123)
     @stats << event(:item_queued,  item_id: 124)
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(/^ *1000000 +A +item_queued +item_id:1$/, out)
@@ -46,7 +46,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
 
   def test_waiting
     @stats << event(:waiting, item_id: 123)
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(/^ *1000000 +A +waiting +item_id:1$/, out)
@@ -54,7 +54,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
 
   def test_continue
     @stats << event(:continue, item_id: 123)
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(/^ *1000000 +A +continue +item_id:1$/, out)
@@ -65,7 +65,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
       :thread_deleted,
       deleted_thread: 123_456,
       thread_count: 12)
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(
@@ -78,7 +78,7 @@ class TestThreadHistoryDisplay < Rake::TestCase # :nodoc:
       :thread_created,
       new_thread: 123_456,
       thread_count: 13)
-    out, _ = capture_io do
+    out, _ = capture_output do
       @display.show
     end
     assert_match(


### PR DESCRIPTION
We used `test-unit` in default gems and bundled gems without `rake`. I would like to reduce dev dependencies from bundled gems.