### PR TITLE
Use Struct instead of OpenStruct.

### DIFF
--- a/lib/rake.rb
+++ b/lib/rake.rb
@@ -30,7 +30,6 @@ require "fileutils"
 require "singleton"
 require "monitor"
 require "optparse"
-require "ostruct"
 
 require "rake/ext/string"
 

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -165,9 +165,7 @@ module Rake
 
     # Application options from the command line
     def options
-      return @options if @options
-
-      @options = Struct.new(
+      @options ||= Struct.new(
         :always_multitask, :backtrace, :build_all, :dryrun,
         :ignore_deprecate, :ignore_system, :job_stats, :load_system,
         :nosearch, :rakelib, :show_all_tasks, :show_prereqs,

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -165,7 +165,15 @@ module Rake
 
     # Application options from the command line
     def options
-      @options ||= OpenStruct.new
+      return @options if @options
+
+      @options = Struct.new(
+        :always_multitask, :backtrace, :build_all, :dryrun,
+        :ignore_deprecate, :ignore_system, :job_stats, :load_system,
+        :nosearch, :rakelib, :show_all_tasks, :show_prereqs,
+        :show_task_pattern, :show_tasks, :silent, :suppress_backtrace_pattern,
+        :thread_pool_size, :trace, :trace_output, :trace_rules
+      ).new
     end
 
     # Return the thread pool used for multithreaded processing.


### PR DESCRIPTION
I will migrate `osturct` as bundled gems at Ruby 3.5. We should remove its dependency from Rake.