### PR TITLE
Add TruffleRuby on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       min_version: 2.3
       engine: cruby-jruby
+      versions: '["truffleruby"]'
 
   test:
     needs: ruby-versions


### PR DESCRIPTION
TruffleRuby was removed in #497 but the issues were fixed in current release TruffleRuby 24.0.