### PR TITLE
Show `chdir` option as a command

### DIFF
--- a/lib/rake/file_utils.rb
+++ b/lib/rake/file_utils.rb
@@ -48,7 +48,7 @@ module FileUtils
     verbose = options.delete :verbose
     noop    = options.delete(:noop) || Rake::FileUtilsExt.nowrite_flag
 
-    Rake.rake_output_message sh_show_command cmd if verbose
+    Rake.rake_output_message sh_show_command(cmd, options) if verbose
 
     unless noop
       res = (Hash === cmd.last) ? system(*cmd) : system(*cmd, options)
@@ -68,7 +68,7 @@ module FileUtils
   end
   private :create_shell_runner
 
-  def sh_show_command(cmd) # :nodoc:
+  def sh_show_command(cmd, options = nil) # :nodoc:
     cmd = cmd.dup
 
     if Hash === cmd.first
@@ -77,7 +77,12 @@ module FileUtils
       cmd[0] = env
     end
 
-    cmd.join " "
+    cmd = cmd.join " "
+    if options and chdir = options[:chdir]
+      "(cd #{chdir} && #{cmd})"
+    else
+      cmd
+    end
   end
   private :sh_show_command
 

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -240,6 +240,20 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
     assert true, "should not fail"
   end
 
+  def test_sh_chdir
+    omit "JRuby does not support spawn options" if jruby?
+
+    Dir.mkdir "chdir_test"
+    out, err = capture_output do
+      verbose(true) {
+        sh "echo ok", chdir: "chdir_test", verbose: true, noop: true
+      }
+    end
+
+    assert_equal "(cd chdir_test && echo ok)\n", err
+    assert_empty out
+  end
+
   def test_sh_bad_option
     # Skip on JRuby because option checking is performed by spawn via system
     # now.


### PR DESCRIPTION
Currently, it is not possible to tell from the output message whether that option is specified for `sh`.