### PR TITLE
Suppressed "<internal:array>:52:in 'Array#each'" from backtrace

### DIFF
--- a/lib/rake/backtrace.rb
+++ b/lib/rake/backtrace.rb
@@ -10,6 +10,7 @@ module Rake
       map { |f| File.expand_path(f) }.
       reject { |s| s.nil? || s =~ /^ *$/ }
     SUPPRESSED_PATHS_RE = SUPPRESSED_PATHS.map { |f| Regexp.quote(f) }.join("|")
+    SUPPRESSED_PATHS_RE << "|^<internal:\\w+>"
     SUPPRESSED_PATHS_RE << "|^org\\/jruby\\/\\w+\\.java" if
       Object.const_defined?(:RUBY_ENGINE) and RUBY_ENGINE == "jruby"
 

--- a/test/test_rake_backtrace.rb
+++ b/test/test_rake_backtrace.rb
@@ -32,6 +32,14 @@ class TestBacktraceSuppression < Rake::TestCase # :nodoc:
 
     assert_equal paths, actual
   end
+
+  def test_ruby_array_each_suppressed
+    paths = ["<internal:array>:52:in 'Array#each'"]
+
+    actual = Rake::Backtrace.collapse(paths)
+
+    assert_equal [], actual
+  end
 end
 
 class TestRakeBacktrace < Rake::TestCase # :nodoc:


### PR DESCRIPTION
We should truncate `<internal:...` message from the following backtrace.


```
rake aborted!
Command failed with status (1)
<internal:array>:52:in 'Array#each'
<internal:array>:52:in 'Array#each'
```

These messages are shown from Ruby 3.4
