### PR TITLE
Handle for SIGTERM

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -94,6 +94,8 @@ module Rake
           # Backward compatibility for capistrano
           args = handle_options
         end
+
+        setup_signal_handling
         load_debug_at_stop_feature
         collect_command_line_tasks(args)
       end
@@ -848,6 +850,13 @@ module Rake
       options.trace                      = false
       options.trace_output               = $stderr
       options.trace_rules                = false
+    end
+
+    def setup_signal_handling
+      Signal.trap("TERM") do
+        puts "SIGTERM received, exiting..."
+        exit 128 + Signal.list["TERM"] # 143
+      end
     end
 
   end

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -498,4 +498,18 @@ module RakefileDefinitions
       puts FL
     STAND_ALONE
   end
+
+  def rakefile_with_long_running_task
+    rakefile <<-TEST_TASK
+  require 'rake/testtask'
+
+  task :default => :test
+  Rake::TestTask.new(:test) do |t|
+  t.test_files = ['a_test.rb']
+  end
+    TEST_TASK
+    open "a_test.rb", "w" do |io|
+       io << "sleep 20"
+     end
+  end
 end

--- a/test/support/ruby_runner.rb
+++ b/test/support/ruby_runner.rb
@@ -21,7 +21,7 @@ module RubyRunner
 
     Open3.popen3(RUBY, *option_list) do |inn, out, err, wait|
       inn.close
-
+      @pid = wait.pid
       @exit = wait ? wait.value : $?
       @out = out.read
       @err = err.read

--- a/test/test_rake_functional.rb
+++ b/test/test_rake_functional.rb
@@ -516,6 +516,20 @@ class TestRakeFunctional < Rake::TestCase # :nodoc:
     assert_equal 0, @exit.exitstatus unless uncertain_exit_status?
   end
 
+  # Test that SIGTERM is handled gracefully
+  def test_sigterm_handling
+    if !jruby? && can_detect_signals?
+      rakefile_with_long_running_task
+      Thread.new { rake }
+      sleep 0.5
+      Process.kill("TERM", @pid)
+      _, status = Process.wait2(@pid)
+      assert_equal(143, status.exitstatus, "Process should exit with status 143")
+    else
+      omit "Signal detection seems broken on this system"
+    end
+  end
+
   private
 
   # We are unable to accurately verify that Rake returns a proper


### PR DESCRIPTION
In containerized workloads, it's common to receive a `SIGTERM` signal when a pod or task is shutting down. Currently, when this occurs, the `rake` task throws a `SignalException` and returns a status code of `1`. This behavior can be misinterpreted by container orchestration systems (like Fargate, Kubernetes, etc.) as an error, rather than a graceful exit.

This PR proposes that, when a `SIGTERM` signal is received by a `rake` task, it should return an exit code of `143`. This exit code is the standard response for a `SIGTERM`, indicating a proper shutdown was acknowledged and handled gracefully.

I only added this for SIGTERM, but should be extensive for other handlers too if needed in future. 

Related: https://github.com/ruby/rake/issues/272