### PR TITLE
Fix Rake.verbose to return true/false even if unset

### DIFF
--- a/lib/rake/file_utils_ext.rb
+++ b/lib/rake/file_utils_ext.rb
@@ -60,7 +60,7 @@ module Rake
           FileUtilsExt.verbose_flag = oldvalue
         end
       end
-      FileUtilsExt.verbose_flag
+      FileUtilsExt.verbose_flag != DEFAULT && FileUtilsExt.verbose_flag
     end
 
     # Get/set the nowrite flag controlling output from the FileUtils

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -105,6 +105,8 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def test_verbose
+    RakeFileUtils.verbose_flag = Rake::FileUtilsExt::DEFAULT
+    assert_equal false, verbose
     verbose true
     assert_equal true, verbose
     verbose false


### PR DESCRIPTION
Unset returns FileUtilsExt.verbose_flag which is set to Object.new by
default, which is truthy. Compare against DEFAULT and return
verbose_flag only if set.