### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/rake

### DIFF
--- a/rake.gemspec
+++ b/rake.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ruby/rake/issues",
-    "changelog_uri" => "https://github.com/ruby/rake/blob/v#{s.version}/History.rdoc",
+    "changelog_uri" => "https://github.com/ruby/rake/releases",
     "documentation_uri" => "https://ruby.github.io/rake",
     "source_code_uri" => "https://github.com/ruby/rake/tree/v#{s.version}"
   }


### PR DESCRIPTION
The current link points to a file that hasn't been updated since v13.0.6. The github.com releases link looks to be a more reliable target.