### PR TITLE
Interrupt rescuing causes issues with debugger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,7 @@ Layout/CaseIndentation:
 Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
+
+# Exceptions should be rescued with `AllExceptionsExceptOnesWeMustNotRescue`
+Lint/RescueException:
+  Enabled: true

--- a/lib/rake.rb
+++ b/lib/rake.rb
@@ -21,7 +21,17 @@
 # IN THE SOFTWARE.
 #++
 
-module Rake; end
+module Rake
+  module AllExceptionsExceptOnesWeMustNotRescue
+    # These exceptions are dangerous to rescue as rescuing them
+    # would interfere with things we should not interfere with.
+    AVOID_RESCUING = [NoMemoryError, SignalException, Interrupt, SystemExit]
+
+    def self.===(exception)
+      AVOID_RESCUING.none? { |ar| ar === exception }
+    end
+  end
+end
 
 require_relative "rake/version"
 

--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -218,7 +218,7 @@ module Rake
     rescue OptionParser::InvalidOption => ex
       $stderr.puts ex.message
       exit(false)
-    rescue Exception => ex
+    rescue AllExceptionsExceptOnesWeMustNotRescue => ex
       # Exit with error message
       display_error_message(ex)
       exit_because_of_exception(ex)

--- a/lib/rake/promise.rb
+++ b/lib/rake/promise.rb
@@ -62,7 +62,7 @@ module Rake
       stat :will_execute, item_id: object_id
       begin
         @result = @block.call(*@args)
-      rescue Exception => e
+      rescue AllExceptionsExceptOnesWeMustNotRescue => e
         @error = e
       end
       stat :did_execute, item_id: object_id

--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -47,7 +47,7 @@ module Rake
           stat :joining
           @join_cond.wait unless @threads.empty?
           stat :joined
-        rescue Exception => e
+        rescue AllExceptionsExceptOnesWeMustNotRescue => e
           stat :joined
           $stderr.puts e
           $stderr.print "Queue contains #{@queue.size} items. " +


### PR DESCRIPTION
The way Rake rescues exceptions running a task, I think, rescues too much. The problem I encounter is when I am using [debug](https://github.com/ruby/debug) in a test task that runs in a subprocess (via `Kernal#system`) - raising an Interrupt with ctrl+c leaves the terminal in a state where it no longer echoes input.

To reproduce, with the `debug` gem installed and this Rakefile:

```ruby
task(:default) { system("ruby -r debug -e debugger") }
```

Run `rake`; at the debug prompt hit ctrl+c. Your terminal no longer echoes your input; the tty is left in raw mode (I eventually found you can fix this by running `stty -raw`)

I think the solution to this is what RSpec does, rescuing broadly but with some exceptions to the Exceptions - see https://github.com/rspec/rspec-support/blob/v3.13.0/lib/rspec/support.rb#L145-L153

I've copied that in this PR and replaced every `rescue Exception` in `lib/`, though only lib/rake/application.rb affects my usage, I think it should be correct in the others as well.