### PR TITLE
chore: refactor/reformat the heredocs (in tests) ...

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -96,10 +96,10 @@ class Rake::TestCase < Test::Unit::TestCase
     FileUtils.mkdir_p @system_dir
 
     open File.join(@system_dir, "sys1.rake"), "w" do |io|
-      io << <<-SYS
-task "sys1" do
-  puts "SYS1"
-end
+      io << <<~SYS
+        task "sys1" do
+          puts "SYS1"
+        end
       SYS
     end
 

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -3,178 +3,178 @@ module RakefileDefinitions
   include FileUtils
 
   def rakefile_access
-    rakefile <<-ACCESS
-TOP_LEVEL_CONSTANT = 0
+    rakefile <<~ACCESS
+      TOP_LEVEL_CONSTANT = 0
 
-def a_top_level_function
-end
+      def a_top_level_function
+      end
 
-task :default => [:work, :obj, :const]
+      task :default => [:work, :obj, :const]
 
-task :work do
-  begin
-    a_top_level_function
-    puts "GOOD:M Top level methods can be called in tasks"
-  rescue NameError => ex
-    puts "BAD:M  Top level methods can not be called in tasks"
-  end
-end
+      task :work do
+        begin
+          a_top_level_function
+          puts "GOOD:M Top level methods can be called in tasks"
+        rescue NameError => ex
+          puts "BAD:M  Top level methods can not be called in tasks"
+        end
+      end
 
-task :obj do
-  begin
-    Object.new.instance_eval { task :xyzzy }
-    puts "BAD:D  Rake DSL are polluting objects"
-  rescue StandardError => ex
-    puts "GOOD:D Rake DSL are not polluting objects"
-  end
-end
+      task :obj do
+        begin
+          Object.new.instance_eval { task :xyzzy }
+          puts "BAD:D  Rake DSL are polluting objects"
+        rescue StandardError => ex
+          puts "GOOD:D Rake DSL are not polluting objects"
+        end
+      end
 
-task :const do
-  begin
-    TOP_LEVEL_CONSTANT
-    puts "GOOD:C Top level constants are available in tasks"
-  rescue StandardError => ex
-    puts "BAD:C  Top level constants are NOT available in tasks"
-  end
-end
+      task :const do
+        begin
+          TOP_LEVEL_CONSTANT
+          puts "GOOD:C Top level constants are available in tasks"
+        rescue StandardError => ex
+          puts "BAD:C  Top level constants are NOT available in tasks"
+        end
+      end
     ACCESS
   end
 
   def rakefile_test_task
-    rakefile <<-RAKEFILE
-    require "rake/testtask"
+    rakefile <<~RAKEFILE
+      require "rake/testtask"
 
-    Rake::TestTask.new(:unit) do |t|
-      t.description = "custom test task description"
-    end
+      Rake::TestTask.new(:unit) do |t|
+        t.description = "custom test task description"
+      end
     RAKEFILE
   end
 
   def rakefile_test_task_verbose
-    rakefile <<-RAKEFILE
-    require "rake/testtask"
+    rakefile <<~RAKEFILE
+      require "rake/testtask"
 
-    Rake::TestTask.new(:unit) do |t|
-      t.verbose = true
-    end
+      Rake::TestTask.new(:unit) do |t|
+        t.verbose = true
+      end
     RAKEFILE
   end
 
   def rakefile_chains
-    rakefile <<-DEFAULT
-task :default => "play.app"
+    rakefile <<~DEFAULT
+      task :default => "play.app"
 
-file "play.scpt" => "base" do |t|
-  cp t.prerequisites.first, t.name
-end
+      file "play.scpt" => "base" do |t|
+        cp t.prerequisites.first, t.name
+      end
 
-rule ".app" => ".scpt" do |t|
-  cp t.source, t.name
-end
+      rule ".app" => ".scpt" do |t|
+        cp t.source, t.name
+      end
 
-file 'base' do
-  touch 'base'
-end
+      file 'base' do
+        touch 'base'
+      end
     DEFAULT
   end
 
   def rakefile_file_chains
-    rakefile <<-RAKEFILE
-file "fileA" do |t|
-  sh "echo contentA >\#{t.name}"
-end
+    rakefile <<~RAKEFILE
+      file "fileA" do |t|
+        sh "echo contentA >\#{t.name}"
+      end
 
-file "fileB" => "fileA" do |t|
-  sh "(cat fileA; echo transformationB) >\#{t.name}"
-end
+      file "fileB" => "fileA" do |t|
+        sh "(cat fileA; echo transformationB) >\#{t.name}"
+      end
 
-file "fileC" => "fileB" do |t|
-  sh "(cat fileB; echo transformationC) >\#{t.name}"
-end
+      file "fileC" => "fileB" do |t|
+        sh "(cat fileB; echo transformationC) >\#{t.name}"
+      end
 
-task default: "fileC"
+      task default: "fileC"
     RAKEFILE
   end
 
   def rakefile_comments
-    rakefile <<-COMMENTS
-# comment for t1
-task :t1 do
-end
+    rakefile <<~COMMENTS
+      # comment for t1
+      task :t1 do
+      end
 
-# no comment or task because there's a blank line
+      # no comment or task because there's a blank line
 
-task :t2 do
-end
+      task :t2 do
+      end
 
-desc "override comment for t3"
-# this is not the description
-multitask :t3 do
-end
+      desc "override comment for t3"
+      # this is not the description
+      multitask :t3 do
+      end
 
-# this is not the description
-desc "override comment for t4"
-file :t4 do
-end
+      # this is not the description
+      desc "override comment for t4"
+      file :t4 do
+      end
     COMMENTS
   end
 
   def rakefile_override
-    rakefile <<-OVERRIDE
-    task :t1 do
-      puts :foo
-    end
+    rakefile <<~OVERRIDE
+      task :t1 do
+        puts :foo
+      end
 
-    task :t1 do
-      puts :bar
-    end
+      task :t1 do
+        puts :bar
+      end
     OVERRIDE
   end
 
   def rakefile_default
-    rakefile <<-DEFAULT
-if ENV['TESTTOPSCOPE']
-  puts "TOPSCOPE"
-end
+    rakefile <<~DEFAULT
+      if ENV['TESTTOPSCOPE']
+        puts "TOPSCOPE"
+      end
 
-task :default do
-  puts "DEFAULT"
-end
+      task :default do
+        puts "DEFAULT"
+      end
 
-task :other => [:default] do
-  puts "OTHER"
-end
+      task :other => [:default] do
+        puts "OTHER"
+      end
 
-task :task_scope do
-  if ENV['TESTTASKSCOPE']
-    puts "TASKSCOPE"
-  end
-end
+      task :task_scope do
+        if ENV['TESTTASKSCOPE']
+          puts "TASKSCOPE"
+        end
+      end
     DEFAULT
   end
 
   def rakefile_dryrun
-    rakefile <<-DRYRUN
-task :default => ["temp_main"]
+    rakefile <<~DRYRUN
+      task :default => ["temp_main"]
 
-file "temp_main" => [:all_apps]  do touch "temp_main" end
+      file "temp_main" => [:all_apps]  do touch "temp_main" end
 
-task :all_apps => [:one, :two]
-task :one => ["temp_one"]
-task :two => ["temp_two"]
+      task :all_apps => [:one, :two]
+      task :one => ["temp_one"]
+      task :two => ["temp_two"]
 
-file "temp_one" do |t|
-  touch "temp_one"
-end
-file "temp_two" do |t|
-  touch "temp_two"
-end
+      file "temp_one" do |t|
+        touch "temp_one"
+      end
+      file "temp_two" do |t|
+        touch "temp_two"
+      end
 
-task :clean do
-  ["temp_one", "temp_two", "temp_main"].each do |file|
-    rm_f file
-  end
-end
+      task :clean do
+        ["temp_one", "temp_two", "temp_main"].each do |file|
+          rm_f file
+        end
+      end
     DRYRUN
 
     FileUtils.touch "temp_main"
@@ -187,77 +187,77 @@ end
     FileUtils.mkdir_p "rakelib"
 
     open File.join("rakelib", "extra.rake"), "w" do |io|
-      io << <<-EXTRA_RAKE
-# Added for testing
+      io << <<~EXTRA_RAKE
+        # Added for testing
 
-namespace :extra do
-  desc "An Extra Task"
-  task :extra do
-    puts "Read all about it"
-  end
-end
+        namespace :extra do
+          desc "An Extra Task"
+          task :extra do
+            puts "Read all about it"
+          end
+        end
       EXTRA_RAKE
     end
   end
 
   def rakefile_file_creation
-    rakefile <<-'FILE_CREATION'
-N = 2
+    rakefile <<~'FILE_CREATION'
+      N = 2
 
-task :default => :run
+      task :default => :run
 
-BUILD_DIR = 'build'
-task :clean do
-  rm_rf 'build'
-  rm_rf 'src'
-end
+      BUILD_DIR = 'build'
+      task :clean do
+        rm_rf 'build'
+        rm_rf 'src'
+      end
 
-task :run
+      task :run
 
-TARGET_DIR = 'build/copies'
+      TARGET_DIR = 'build/copies'
 
-FileList['src/*'].each do |src|
-  directory TARGET_DIR
-  target = File.join TARGET_DIR, File.basename(src)
-  file target => [src, TARGET_DIR] do
-    cp src, target
-  end
-  task :run => target
-end
+      FileList['src/*'].each do |src|
+        directory TARGET_DIR
+        target = File.join TARGET_DIR, File.basename(src)
+        file target => [src, TARGET_DIR] do
+          cp src, target
+        end
+        task :run => target
+      end
 
-task :prep => :clean do
-  mkdir_p 'src'
-  N.times do |n|
-    touch "src/foo#{n}"
-  end
-end
+      task :prep => :clean do
+        mkdir_p 'src'
+        N.times do |n|
+          touch "src/foo#{n}"
+        end
+      end
     FILE_CREATION
   end
 
   def rakefile_imports
-    rakefile <<-IMPORTS
-require 'rake/loaders/makefile'
+    rakefile <<~IMPORTS
+      require 'rake/loaders/makefile'
 
-task :default
+      task :default
 
-task :other do
-  puts "OTHER"
-end
+      task :other do
+        puts "OTHER"
+      end
 
-file "dynamic_deps" do |t|
-  open(t.name, "w") do |f| f.puts "puts 'DYNAMIC'" end
-end
+      file "dynamic_deps" do |t|
+        open(t.name, "w") do |f| f.puts "puts 'DYNAMIC'" end
+      end
 
-import "dynamic_deps"
-import "static_deps"
-import "static_deps"
-import "deps.mf"
-puts "FIRST"
+      import "dynamic_deps"
+      import "static_deps"
+      import "static_deps"
+      import "deps.mf"
+      puts "FIRST"
     IMPORTS
 
     open "deps.mf", "w" do |io|
-      io << <<-DEPS
-default: other
+      io << <<~DEPS
+        default: other
       DEPS
     end
 
@@ -267,115 +267,115 @@ default: other
   end
 
   def rakefile_regenerate_imports
-    rakefile <<-REGENERATE_IMPORTS
-task :default
+    rakefile <<~REGENERATE_IMPORTS
+      task :default
 
-task :regenerate do
-  open("deps", "w") do |f|
-    f << <<-CONTENT
-file "deps" => :regenerate
-puts "REGENERATED"
-    CONTENT
-  end
-end
+      task :regenerate do
+        open("deps", "w") do |f|
+          f << <<~CONTENT
+      file "deps" => :regenerate
+      puts "REGENERATED"
+          CONTENT
+        end
+      end
 
-import "deps"
+      import "deps"
     REGENERATE_IMPORTS
 
     open "deps", "w" do |f|
-      f << <<-CONTENT
-file "deps" => :regenerate
-puts "INITIAL"
+      f << <<~CONTENT
+        file "deps" => :regenerate
+        puts "INITIAL"
       CONTENT
     end
   end
 
   def rakefile_multidesc
-    rakefile <<-MULTIDESC
-task :b
+    rakefile <<~MULTIDESC
+      task :b
 
-desc "A"
-task :a
+      desc "A"
+      task :a
 
-desc "B"
-task :b
+      desc "B"
+      task :b
 
-desc "A2"
-task :a
+      desc "A2"
+      task :a
 
-task :c
+      task :c
 
-desc "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-task :d
+      desc "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      task :d
     MULTIDESC
   end
 
   def rakefile_namespace
-    rakefile <<-NAMESPACE
-desc "copy"
-task :copy do
-  puts "COPY"
-end
+    rakefile <<~NAMESPACE
+      desc "copy"
+      task :copy do
+        puts "COPY"
+      end
 
-namespace "nest" do
-  desc "nest copy"
-  task :copy do
-    puts "NEST COPY"
-  end
-  task :xx => :copy
-end
+      namespace "nest" do
+        desc "nest copy"
+        task :copy do
+          puts "NEST COPY"
+        end
+        task :xx => :copy
+      end
 
-anon_ns = namespace do
-  desc "anonymous copy task"
-  task :copy do
-    puts "ANON COPY"
-  end
-end
+      anon_ns = namespace do
+        desc "anonymous copy task"
+        task :copy do
+          puts "ANON COPY"
+        end
+      end
 
-desc "Top level task to run the anonymous version of copy"
-task :anon => anon_ns[:copy]
+      desc "Top level task to run the anonymous version of copy"
+      task :anon => anon_ns[:copy]
 
-namespace "very" do
-  namespace "nested" do
-    task "run" => "rake:copy"
-  end
-end
+      namespace "very" do
+        namespace "nested" do
+          task "run" => "rake:copy"
+        end
+      end
 
-namespace "a" do
-  desc "Run task in the 'a' namespace"
-  task "run" do
-    puts "IN A"
-  end
-end
+      namespace "a" do
+        desc "Run task in the 'a' namespace"
+        task "run" do
+          puts "IN A"
+        end
+      end
 
-namespace "b" do
-  desc "Run task in the 'b' namespace"
-  task "run" => "a:run" do
-    puts "IN B"
-  end
-end
+      namespace "b" do
+        desc "Run task in the 'b' namespace"
+        task "run" => "a:run" do
+          puts "IN B"
+        end
+      end
 
-namespace "file1" do
-  file "xyz.rb" do
-    puts "XYZ1"
-  end
-end
+      namespace "file1" do
+        file "xyz.rb" do
+          puts "XYZ1"
+        end
+      end
 
-namespace "file2" do
-  file "xyz.rb" do
-    puts "XYZ2"
-  end
-end
+      namespace "file2" do
+        file "xyz.rb" do
+          puts "XYZ2"
+        end
+      end
 
-namespace "scopedep" do
-  task :prepare do
-    touch "scopedep.rb"
-    puts "PREPARE"
-  end
-  file "scopedep.rb" => [:prepare] do
-    puts "SCOPEDEP"
-  end
-end
+      namespace "scopedep" do
+        task :prepare do
+          touch "scopedep.rb"
+          puts "PREPARE"
+        end
+        file "scopedep.rb" => [:prepare] do
+          puts "SCOPEDEP"
+        end
+      end
     NAMESPACE
   end
 
@@ -388,18 +388,18 @@ end
 
     Dir.chdir "rakelib" do
       open "test1.rb", "w" do |io|
-        io << <<-TEST1
-task :default do
-  puts "TEST1"
-end
+        io << <<~TEST1
+          task :default do
+            puts "TEST1"
+          end
         TEST1
       end
 
       open "test2.rake", "w" do |io|
-        io << <<-TEST1
-task :default do
-  puts "TEST2"
-end
+        io << <<~TEST1
+          task :default do
+            puts "TEST2"
+          end
         TEST1
       end
     end
@@ -421,61 +421,61 @@ end
   end
 
   def rakefile_verbose
-    rakefile <<-VERBOSE
-task :standalone_verbose_true do
-  verbose true
-  sh "#{RUBY} -e '0'"
-end
+    rakefile <<~VERBOSE
+      task :standalone_verbose_true do
+        verbose true
+        sh "#{RUBY} -e '0'"
+      end
 
-task :standalone_verbose_false do
-  verbose false
-  sh "#{RUBY} -e '0'"
-end
+      task :standalone_verbose_false do
+        verbose false
+        sh "#{RUBY} -e '0'"
+      end
 
-task :inline_verbose_default do
-  sh "#{RUBY} -e '0'"
-end
+      task :inline_verbose_default do
+        sh "#{RUBY} -e '0'"
+      end
 
-task :inline_verbose_false do
-  sh "#{RUBY} -e '0'", :verbose => false
-end
+      task :inline_verbose_false do
+        sh "#{RUBY} -e '0'", :verbose => false
+      end
 
-task :inline_verbose_true do
-  sh "#{RUBY} -e '0'", :verbose => true
-end
+      task :inline_verbose_true do
+        sh "#{RUBY} -e '0'", :verbose => true
+      end
 
-task :block_verbose_true do
-  verbose(true) do
-    sh "#{RUBY} -e '0'"
-  end
-end
+      task :block_verbose_true do
+        verbose(true) do
+          sh "#{RUBY} -e '0'"
+        end
+      end
 
-task :block_verbose_false do
-  verbose(false) do
-    sh "#{RUBY} -e '0'"
-  end
-end
+      task :block_verbose_false do
+        verbose(false) do
+          sh "#{RUBY} -e '0'"
+        end
+      end
     VERBOSE
   end
 
   def rakefile_test_signal
-    rakefile <<-TEST_SIGNAL
-require 'rake/testtask'
+    rakefile <<~TEST_SIGNAL
+      require 'rake/testtask'
 
-Rake::TestTask.new(:a) do |t|
-  t.test_files = ['a_test.rb']
-end
+      Rake::TestTask.new(:a) do |t|
+        t.test_files = ['a_test.rb']
+      end
 
-Rake::TestTask.new(:b) do |t|
-  t.test_files = ['b_test.rb']
-end
+      Rake::TestTask.new(:b) do |t|
+        t.test_files = ['b_test.rb']
+      end
 
-task :test do
-  Rake::Task[:a].invoke
-  Rake::Task[:b].invoke
-end
+      task :test do
+        Rake::Task[:a].invoke
+        Rake::Task[:b].invoke
+      end
 
-task :default => :test
+      task :default => :test
     TEST_SIGNAL
     open "a_test.rb", "w" do |io|
       io << 'puts "ATEST"' << "\n"
@@ -489,13 +489,13 @@ task :default => :test
   end
 
   def rakefile_failing_test_task
-    rakefile <<-TEST_TASK
-require 'rake/testtask'
+    rakefile <<~TEST_TASK
+      require 'rake/testtask'
 
-task :default => :test
-Rake::TestTask.new(:test) do |t|
-  t.test_files = ['a_test.rb']
-end
+      task :default => :test
+      Rake::TestTask.new(:test) do |t|
+        t.test_files = ['a_test.rb']
+      end
     TEST_TASK
     open "a_test.rb", "w" do |io|
       io << "require 'minitest/autorun'\n"

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -416,42 +416,42 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def check_no_expansion
-    command "check_no_expansion.rb", <<-CHECK_EXPANSION
-if ARGV[0] != ARGV[1]
-  exit 0
-else
-  exit 1
-end
+    command "check_no_expansion.rb", <<~CHECK_EXPANSION
+      if ARGV[0] != ARGV[1]
+        exit 0
+      else
+        exit 1
+      end
     CHECK_EXPANSION
   end
 
   def check_environment
-    command "check_environment.rb", <<-CHECK_ENVIRONMENT
-if ENV[ARGV[0]] != ARGV[1]
-  exit 1
-else
-  exit 0
-end
+    command "check_environment.rb", <<~CHECK_ENVIRONMENT
+      if ENV[ARGV[0]] != ARGV[1]
+        exit 1
+      else
+        exit 0
+      end
     CHECK_ENVIRONMENT
   end
 
   def check_expansion
-    command "check_expansion.rb", <<-CHECK_EXPANSION
-if ARGV[0] != ARGV[1]
-  exit 1
-else
-  exit 0
-end
+    command "check_expansion.rb", <<~CHECK_EXPANSION
+      if ARGV[0] != ARGV[1]
+        exit 1
+      else
+        exit 0
+      end
     CHECK_EXPANSION
   end
 
   def echocommand
-    command "echocommand.rb", <<-ECHOCOMMAND
-#!/usr/bin/env ruby
+    command "echocommand.rb", <<~ECHOCOMMAND
+      #!/usr/bin/env ruby
 
-puts "echocommand.rb"
+      puts "echocommand.rb"
 
-exit 0
+      exit 0
     ECHOCOMMAND
   end
 
@@ -466,10 +466,10 @@ exit 0
   end
 
   def shellcommand
-    command "shellcommand.rb", <<-SHELLCOMMAND
-#!/usr/bin/env ruby
+    command "shellcommand.rb", <<~SHELLCOMMAND
+      #!/usr/bin/env ruby
 
-exit((ARGV[0] || "0").to_i)
+      exit((ARGV[0] || "0").to_i)
     SHELLCOMMAND
   end
 

--- a/test/test_rake_makefile_loader.rb
+++ b/test/test_rake_makefile_loader.rb
@@ -9,21 +9,21 @@ class TestRakeMakefileLoader < Rake::TestCase  # :nodoc:
     Dir.chdir @tempdir
 
     open "sample.mf", "w" do |io|
-      io << <<-'SAMPLE_MF'
-# Comments
-a: a1 a2 a3 a4
-b: b1 b2 b3 \
-   b4 b5 b6\
-# Mid: Comment
-b7
+      io << <<~'SAMPLE_MF'
+        # Comments
+        a: a1 a2 a3 a4
+        b: b1 b2 b3 \
+           b4 b5 b6\
+        # Mid: Comment
+        b7
 
- a : a5 a6 a7
-c: c1
-d: d1 d2 \
+         a : a5 a6 a7
+        c: c1
+        d: d1 d2 \
 
-e f : e1 f1
+        e f : e1 f1
 
-g\ 0: g1 g\ 2 g\ 3 g4
+        g\ 0: g1 g\ 2 g\ 3 g4
       SAMPLE_MF
     end
 

--- a/test/test_rake_task_with_arguments.rb
+++ b/test/test_rake_task_with_arguments.rb
@@ -84,28 +84,28 @@ class TestRakeTaskWithArguments < Rake::TestCase # :nodoc:
   def test_actions_adore_keywords
     # https://github.com/ruby/rake/pull/174#issuecomment-263460761
     omit if jruby9?
-    eval <<-RUBY, binding, __FILE__, __LINE__+1
-    notes = []
-    t = task :t, [:reqr, :ovrd, :dflt] # required, overridden-optional, default-optional
-    verify = lambda do |name, expecteds, actuals|
-      notes << name
-      assert_equal expecteds.length, actuals.length
-      expecteds.zip(actuals) { |e, a| assert_equal e, a, "(TEST \#{name})" }
-    end
+    eval <<~RUBY, binding, __FILE__, __LINE__+1
+      notes = []
+      t = task :t, [:reqr, :ovrd, :dflt] # required, overridden-optional, default-optional
+      verify = lambda do |name, expecteds, actuals|
+        notes << name
+        assert_equal expecteds.length, actuals.length
+        expecteds.zip(actuals) { |e, a| assert_equal e, a, "(TEST \#{name})" }
+      end
 
-    t.enhance { |dflt: 'd', **| verify.call :a, ['d'], [dflt] }
-    t.enhance { |ovrd: '-', **| verify.call :b, ['o'], [ovrd] }
-    t.enhance { |reqr:    , **| verify.call :c, ['r'], [reqr] }
+      t.enhance { |dflt: 'd', **| verify.call :a, ['d'], [dflt] }
+      t.enhance { |ovrd: '-', **| verify.call :b, ['o'], [ovrd] }
+      t.enhance { |reqr:    , **| verify.call :c, ['r'], [reqr] }
 
-    t.enhance { |t2, dflt: 'd', **| verify.call :d, [t,'d'], [t2,dflt] }
-    t.enhance { |t2, ovrd: 'd', **| verify.call :e, [t,'o'], [t2,ovrd] }
-    t.enhance { |t2, reqr:    , **| verify.call :f, [t,'r'], [t2,reqr] }
+      t.enhance { |t2, dflt: 'd', **| verify.call :d, [t,'d'], [t2,dflt] }
+      t.enhance { |t2, ovrd: 'd', **| verify.call :e, [t,'o'], [t2,ovrd] }
+      t.enhance { |t2, reqr:    , **| verify.call :f, [t,'r'], [t2,reqr] }
 
-    t.enhance { |t2, dflt: 'd', reqr:, **| verify.call :g, [t,'d','r'], [t2,dflt,reqr] }
-    t.enhance { |t2, ovrd: '-', reqr:, **| verify.call :h, [t,'o','r'], [t2,ovrd,reqr] }
+      t.enhance { |t2, dflt: 'd', reqr:, **| verify.call :g, [t,'d','r'], [t2,dflt,reqr] }
+      t.enhance { |t2, ovrd: '-', reqr:, **| verify.call :h, [t,'o','r'], [t2,ovrd,reqr] }
 
-    t.invoke('r', 'o')
-    assert_equal [*:a..:h], notes
+      t.invoke('r', 'o')
+      assert_equal [*:a..:h], notes
     RUBY
   end
 


### PR DESCRIPTION
... by consistently using the squiggly heredoc syntax (using `<<~` instead of `<<-`) and by fixing the indentation of all multi-line heredoc content accordingly.

Since 704c2f10667b4d244191e1bff50d92f34a0e861c (April 2023), `rake` has been targeting `ruby v2.3` _(and above)_, which is the `ruby` version that introduced @avdi's suggested [squiggly heredoc syntax](https://avdi.codes/about-the-ruby-squiggly-heredoc-syntax/), so there should be no issue with using it throughout the `rake` codebase.