### PR TITLE
chore: refactor how temporary files are created (in tests)

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -95,21 +95,17 @@ class Rake::TestCase < Test::Unit::TestCase
 
     FileUtils.mkdir_p @system_dir
 
-    open File.join(@system_dir, "sys1.rake"), "w" do |io|
-      io << <<~SYS
-        task "sys1" do
-          puts "SYS1"
-        end
-      SYS
-    end
+    File.write File.join(@system_dir, "sys1.rake"), <<~SYS
+      task "sys1" do
+        puts "SYS1"
+      end
+    SYS
 
     ENV["RAKE_SYSTEM"] = @system_dir
   end
 
   def rakefile(contents)
-    open "Rakefile", "w" do |io|
-      io << contents
-    end
+    File.write "Rakefile", contents
   end
 
   def jruby?

--- a/test/support/rakefile_definitions.rb
+++ b/test/support/rakefile_definitions.rb
@@ -186,18 +186,16 @@ module RakefileDefinitions
 
     FileUtils.mkdir_p "rakelib"
 
-    open File.join("rakelib", "extra.rake"), "w" do |io|
-      io << <<~EXTRA_RAKE
-        # Added for testing
+    File.write File.join("rakelib", "extra.rake"), <<~EXTRA_RAKE
+      # Added for testing
 
-        namespace :extra do
-          desc "An Extra Task"
-          task :extra do
-            puts "Read all about it"
-          end
+      namespace :extra do
+        desc "An Extra Task"
+        task :extra do
+          puts "Read all about it"
         end
-      EXTRA_RAKE
-    end
+      end
+    EXTRA_RAKE
   end
 
   def rakefile_file_creation
@@ -245,7 +243,7 @@ module RakefileDefinitions
       end
 
       file "dynamic_deps" do |t|
-        open(t.name, "w") do |f| f.puts "puts 'DYNAMIC'" end
+        File.write t.name, "puts 'DYNAMIC'\n"
       end
 
       import "dynamic_deps"
@@ -255,15 +253,11 @@ module RakefileDefinitions
       puts "FIRST"
     IMPORTS
 
-    open "deps.mf", "w" do |io|
-      io << <<~DEPS
-        default: other
-      DEPS
-    end
+    File.write "deps.mf", <<~DEPS
+      default: other
+    DEPS
 
-    open "static_deps", "w" do |f|
-      f.puts 'puts "STATIC"'
-    end
+    File.write "static_deps", "puts 'STATIC'\n"
   end
 
   def rakefile_regenerate_imports
@@ -271,23 +265,19 @@ module RakefileDefinitions
       task :default
 
       task :regenerate do
-        open("deps", "w") do |f|
-          f << <<~CONTENT
-      file "deps" => :regenerate
-      puts "REGENERATED"
-          CONTENT
-        end
+        File.write "deps", <<~CONTENT
+          file "deps" => :regenerate
+          puts "REGENERATED"
+        CONTENT
       end
 
       import "deps"
     REGENERATE_IMPORTS
 
-    open "deps", "w" do |f|
-      f << <<~CONTENT
-        file "deps" => :regenerate
-        puts "INITIAL"
-      CONTENT
-    end
+    File.write "deps", <<~CONTENT
+      file "deps" => :regenerate
+      puts "INITIAL"
+    CONTENT
   end
 
   def rakefile_multidesc
@@ -387,28 +377,22 @@ module RakefileDefinitions
     FileUtils.mkdir_p "rakelib"
 
     Dir.chdir "rakelib" do
-      open "test1.rb", "w" do |io|
-        io << <<~TEST1
-          task :default do
-            puts "TEST1"
-          end
-        TEST1
-      end
+      File.write "test1.rb", <<~TEST1
+        task :default do
+          puts "TEST1"
+        end
+      TEST1
 
-      open "test2.rake", "w" do |io|
-        io << <<~TEST1
-          task :default do
-            puts "TEST2"
-          end
-        TEST1
-      end
+      File.write "test2.rake", <<~TEST2
+        task :default do
+          puts "TEST2"
+        end
+      TEST2
     end
   end
 
   def rakefile_rbext
-    open "rakefile.rb", "w" do |io|
-      io << 'task :default do puts "OK" end'
-    end
+    File.write "rakefile.rb", 'task :default do puts "OK" end'
   end
 
   def rakefile_unittest
@@ -477,15 +461,15 @@ module RakefileDefinitions
 
       task :default => :test
     TEST_SIGNAL
-    open "a_test.rb", "w" do |io|
-      io << 'puts "ATEST"' << "\n"
-      io << "$stdout.flush" << "\n"
-      io << 'Process.kill("TERM", $$)' << "\n"
-    end
-    open "b_test.rb", "w" do |io|
-      io << 'puts "BTEST"' << "\n"
-      io << "$stdout.flush" << "\n"
-    end
+    File.write "a_test.rb", <<~A_TEST
+      puts "ATEST"
+      $stdout.flush
+      Process.kill("TERM", $$)
+    A_TEST
+    File.write "b_test.rb", <<~B_TEST
+      puts "BTEST"
+      $stdout.flush
+    B_TEST
   end
 
   def rakefile_failing_test_task
@@ -497,21 +481,21 @@ module RakefileDefinitions
         t.test_files = ['a_test.rb']
       end
     TEST_TASK
-    open "a_test.rb", "w" do |io|
-      io << "require 'minitest/autorun'\n"
-      io << "class ExitTaskTest < Minitest::Test\n"
-      io << "  def test_exit\n"
-      io << "    assert false, 'this should fail'\n"
-      io << "  end\n"
-      io << "end\n"
-    end
+    File.write "a_test.rb", <<~A_TEST
+      require 'minitest/autorun'
+      class ExitTaskTest < Minitest::Test
+        def test_exit
+          assert false, 'this should fail'
+        end
+      end
+    A_TEST
   end
 
   def rakefile_stand_alone_filelist
-    open "stand_alone_filelist.rb", "w" do |io|
-      io << "require 'rake/file_list'\n"
-      io << "FL = Rake::FileList['*.rb']\n"
-      io << "puts FL\n"
-    end
+    File.write "stand_alone_filelist.rb", <<~STAND_ALONE
+      require 'rake/file_list'
+      FL = Rake::FileList['*.rb']
+      puts FL
+    STAND_ALONE
   end
 end

--- a/test/test_rake_application_options.rb
+++ b/test/test_rake_application_options.rb
@@ -184,9 +184,9 @@ class TestRakeApplicationOptions < Rake::TestCase # :nodoc:
   def test_require
     $LOAD_PATH.unshift @tempdir
 
-    open "reqfile.rb",    "w" do |io| io << "TESTING_REQUIRE << 1" end
-    open "reqfile2.rb",   "w" do |io| io << "TESTING_REQUIRE << 2" end
-    open "reqfile3.rake", "w" do |io| io << "TESTING_REQUIRE << 3" end
+    File.write "reqfile.rb",    "TESTING_REQUIRE << 1"
+    File.write "reqfile2.rb",   "TESTING_REQUIRE << 2"
+    File.write "reqfile3.rake", "TESTING_REQUIRE << 3"
 
     flags(["--require", "reqfile"], "-rreqfile2", "-rreqfile3")
 

--- a/test/test_rake_definitions.rb
+++ b/test/test_rake_definitions.rb
@@ -78,7 +78,7 @@ class TestRakeDefinitions < Rake::TestCase # :nodoc:
   def create_existing_file
     Dir.mkdir File.dirname(EXISTINGFILE) unless
       File.exist?(File.dirname(EXISTINGFILE))
-    open(EXISTINGFILE, "w") do |f| f.puts "HI" end unless
+    File.write(EXISTINGFILE, "HI") unless
       File.exist?(EXISTINGFILE)
   end
 

--- a/test/test_rake_file_list.rb
+++ b/test/test_rake_file_list.rb
@@ -23,10 +23,10 @@ class TestRakeFileList < Rake::TestCase # :nodoc:
     FileUtils.touch "abc.x"
     FileUtils.touch "existing"
 
-    open "xyzzy.txt", "w" do |io|
-      io.puts "x"
-      io.puts "XYZZY"
-    end
+    File.write "xyzzy.txt", <<~EOTEXT
+      x
+      XYZZY
+    EOTEXT
 
   end
 

--- a/test/test_rake_file_task.rb
+++ b/test/test_rake_file_task.rb
@@ -27,7 +27,7 @@ class TestRakeFileTask < Rake::TestCase # :nodoc:
     assert ftask.needed?, "file should be needed"
     assert_equal Rake::LATE, ftask.timestamp
 
-    open(ftask.name, "w") { |f| f.puts "HI" }
+    File.write(ftask.name, "HI\n")
 
     assert_nil ftask.prerequisites.map { |n| Task[n].timestamp }.max
     assert ! ftask.needed?, "file should not be needed"

--- a/test/test_rake_file_utils.rb
+++ b/test/test_rake_file_utils.rb
@@ -56,7 +56,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def test_ln
-    open("a", "w") { |f| f.puts "TEST_LN" }
+    File.write("a", "TEST_LN\n")
 
     Rake::FileUtilsExt.safe_ln("a", "b", verbose: false)
 
@@ -410,9 +410,7 @@ class TestRakeFileUtils < Rake::TestCase # :nodoc:
   end
 
   def command(name, text)
-    open name, "w", 0750 do |io|
-      io << text
-    end
+    File.write(name, text)
   end
 
   def check_no_expansion

--- a/test/test_rake_makefile_loader.rb
+++ b/test/test_rake_makefile_loader.rb
@@ -8,24 +8,22 @@ class TestRakeMakefileLoader < Rake::TestCase  # :nodoc:
   def test_parse
     Dir.chdir @tempdir
 
-    open "sample.mf", "w" do |io|
-      io << <<~'SAMPLE_MF'
-        # Comments
-        a: a1 a2 a3 a4
-        b: b1 b2 b3 \
-           b4 b5 b6\
-        # Mid: Comment
-        b7
+    File.write "sample.mf", <<~'SAMPLE_MF'
+      # Comments
+      a: a1 a2 a3 a4
+      b: b1 b2 b3 \
+         b4 b5 b6\
+      # Mid: Comment
+      b7
 
-         a : a5 a6 a7
-        c: c1
-        d: d1 d2 \
+       a : a5 a6 a7
+      c: c1
+      d: d1 d2 \
 
-        e f : e1 f1
+      e f : e1 f1
 
-        g\ 0: g1 g\ 2 g\ 3 g4
-      SAMPLE_MF
-    end
+      g\ 0: g1 g\ 2 g\ 3 g4
+    SAMPLE_MF
 
     Task.clear
     loader = Rake::MakefileLoader.new


### PR DESCRIPTION
... by consistently using [`File::write`](https://ruby-doc.org/3.3.5/IO.html#method-c-write) instead of [`Kernel#open`](https://ruby-doc.org/3.3.5/Kernel.html#method-i-open).

At the moment, most temporary files (in tests) are written using `Kernel#open` even though sometimes `File::write` is already being used;  this PR refactors all tests to consistently use `File::write`.

It's possibly a matter of style/preference/opinion, but this also makes things slightly more readable and slightly less convoluted; either way, I think `File.write` is a tad more "intention revealing" than `Kernel#open` as well: we are "writing a (Rake-)file" as opposed to "opening a file for writing" ... small but subtle difference. :sweat_smile:

In addition, the content of temporary files is  refactored to consistently use heredocs, instead of a _(quite random)_ mix of heredocs and [`IO#<<`](https://ruby-doc.org/3.3.5/IO.html#method-i-3C-3C) ... double win! :smiley:

PS - so as to not introduce any different behaviour, and to keep things functionally identical, I introduced a couple of newline characters (`"\n"`) even though these appear to be immaterial _(the tests run green with and without them)_ so I'm happy to take them out again.