### PR TITLE
refactor: simplify `Rake::Application#system_dir` method

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -755,14 +755,7 @@ module Rake
 
     # The directory path containing the system wide rakefiles.
     def system_dir # :nodoc:
-      @system_dir ||=
-        begin
-          if ENV["RAKE_SYSTEM"]
-            ENV["RAKE_SYSTEM"]
-          else
-            standard_system_dir
-          end
-        end
+      @system_dir ||= ENV["RAKE_SYSTEM"] || standard_system_dir
     end
 
     # The standard directory containing system wide rake files.


### PR DESCRIPTION
Due to it being a tad convoluted, it took me longer than it probably should have to grok what the `Rake::Application#system_dir` method was trying to do.

I think this simplification makes it a lot more obvious, especially as the same ...

```ruby
hash[:lookup_key] || :default_value
```

... idiom is already used elsewhere in the `rake` codebase.

It also avoids a double hash lookup: one lookup to see if `RAKE_SYSTEM` is set in the `ENV` hash, and - if it is - exactly the same lookup again to actually fetch its value. 🎉 

PS - I was tempted to also include the following change in this PR ... happy to take your steer @hsbt : include it in this one, or issue a separate PR instead? (or else forget about it altogether if it's totally bonkers?) 😅 

```diff
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -765,7 +765,7 @@ module Rake
       end
     else
       def standard_system_dir #:nodoc:
-        File.join(File.expand_path("~"), ".rake")
+        File.join(Dir.home, ".rake")
       end
     end
     private :standard_system_dir
```