### PR TITLE
chore: remove `$trace` global variable / option

### DIFF
--- a/lib/rake.rb
+++ b/lib/rake.rb
@@ -60,8 +60,6 @@ require_relative "rake/task_manager"
 require_relative "rake/application"
 require_relative "rake/backtrace"
 
-$trace = false
-
 # :stopdoc:
 #
 # Some top level Constants.


### PR DESCRIPTION
As [documented in History.rdoc](https://github.com/ruby/rake/blob/master/History.rdoc#changes-in-100-), `rake v10.0.x` stopped supporting Rake options set in global variables, including the `$trace` option ... this PR simply removes the rogue occurrence that was still lingering in the codebase.