### PR TITLE
Revert "Link to Jim's last `rake` commit (not the git tree with that SHA)"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -148,7 +148,7 @@ February 2014. This repository was originally hosted at
 with his passing, has been moved to {ruby/rake}[https://github.com/ruby/rake].
 
 You can view Jim's last commit here:
-https://github.com/jimweirich/rake/commit/336559f28f55bce418e2ebcc0a57548dcbac4025
+https://github.com/jimweirich/rake/tree/336559f28f55bce418e2ebcc0a57548dcbac4025
 
 You can {read more about Jim}[https://en.wikipedia.org/wiki/Jim_Weirich] at Wikipedia.
 


### PR DESCRIPTION
Reverts ruby/rake#593 - as per @jahio's https://github.com/ruby/rake/pull/66#issuecomment-2395153316 and clarification, I now better understand his original intent, so I think it makes sense to revert to the original link ... @hsbt - do you agree?