### PR TITLE
refactor: remove "exposed" `@system_dir` instance variable (in helper method)

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -91,17 +91,17 @@ class Rake::TestCase < Test::Unit::TestCase
   end
 
   def rake_system_dir
-    @system_dir = "system"
+    system_dir = "system"
 
-    FileUtils.mkdir_p @system_dir
+    FileUtils.mkdir_p system_dir
 
-    File.write File.join(@system_dir, "sys1.rake"), <<~SYS
+    File.write File.join(system_dir, "sys1.rake"), <<~SYS
       task "sys1" do
         puts "SYS1"
       end
     SYS
 
-    ENV["RAKE_SYSTEM"] = @system_dir
+    ENV["RAKE_SYSTEM"] = system_dir
   end
 
   def rakefile(contents)

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -338,7 +338,7 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
       load_rakefile
     end
 
-    assert_equal @system_dir, @app.system_dir
+    assert_equal "system", @app.system_dir
     assert_nil @app.rakefile
   rescue SystemExit
     flunk "failed to load rakefile"


### PR DESCRIPTION
It is very unclear why the [`Rake::TestCase#rake_system_dir`](https://github.com/ruby/rake/blob/master/test/helper.rb#L93-L105) helper method:

```ruby
  def rake_system_dir
    @system_dir = "system"

    FileUtils.mkdir_p @system_dir

    File.write File.join(@system_dir, "sys1.rake"), <<~SYS
      task "sys1" do
        puts "SYS1"
      end
    SYS

    ENV["RAKE_SYSTEM"] = @system_dir
  end
```
... creates and sets a `@system_dir` instance variable. :thinking:

On  inspection, it turns out its only use is [the following assertion](https://github.com/ruby/rake/blob/master/test/test_rake_application.rb#L341) in one of the test cases:

```ruby
    assert_equal @system_dir, @app.system_dir
```

... so this PR removes the ivar and hardcodes the expected `"system"` value in the assertion:

```diff
-    assert_equal @system_dir, @app.system_dir
+    assert_equal "system", @app.system_dir
```

This _may_ seem a tad controversial, but as it turns out, the `sys1.rake` Rakefile name and the `SYS1` Rakefile contents _(also "private" - as it were - to that very same utility method)_ are [already hardcoded](https://github.com/search?q=sys1+repo%3Aruby%2Frake+path%3A*.rb+path%3A%2Ftest%2F&type=Code&ref=advsearch&l=&l=) in one of the Rake test cases:

```ruby
$ git grep -i sys1 -- 'test/test*'
test/test_rake_functional.rb:    rake "-g", "sys1"
test/test_rake_functional.rb:    assert_match %r{^SYS1}, @out
test/test_rake_functional.rb:    rake "-g", "sys1", "-T", "extra"
test/test_rake_functional.rb:    rake "sys1", "--trace"
test/test_rake_functional.rb:    assert_match %r{^SYS1}, @out
test/test_rake_functional.rb:    rake "-G", "sys1"
test/test_rake_functional.rb:    rake "--nosearch", "sys1"
test/test_rake_functional.rb:    assert_match %r{^SYS1}, @out
$ _
```

... so the change in this PR just makes things more consistent with the other test cases and assertions.