### PR TITLE
refactor: use `Dir.home` to find `rake`'s standard system dir

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -765,7 +765,7 @@ module Rake
       end
     else
       def standard_system_dir #:nodoc:
-        File.join(File.expand_path("~"), ".rake")
+        File.join(Dir.home, ".rake")
       end
     end
     private :standard_system_dir


### PR DESCRIPTION
Hot on the heels of the changes in #591, this PR proposes a further simplification of `Rake::Application.standard_system_dir()` by using `Dir.home()` instead of `File.expand_path("~")`

As discussed here:

https://bugs.ruby-lang.org/issues/1027

... this is a much more idiomatic way to determine the home directory of the current user, and has been part of Ruby [since 2009](https://github.com/ruby/ruby/commit/043f665274006e4f040e681e0a1aee4975cf30b5) (`ruby 1.9.2`).

Thanks, @hsbt! :pray: