### PR TITLE
refactor: only include `lib` in `$LOAD_PATH` if not included yet

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-$:.unshift File.expand_path("../../lib", __FILE__)
+
+lib = File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 begin
   if ENV["COVERALLS"]


### PR DESCRIPTION
[![released](https://released.blabberate.com/p/ruby/rake/610/badge.svg)](https://released.blabberate.com/p/ruby/rake/610) **refactor: only include `lib` in `$LOAD_PATH` if not included yet**

---

When running the `rake` tests using `bundle exec rake test`, the `lib` directory is added to `$LOAD_PATH` twice, once by the `Rakefile`, and again by `test_helper.rb` ... the change in this PR only adds it if it isn't present already, following the idiom that's already used by the `Rakefile`:

```ruby
lib = File.expand_path("../lib", __FILE__)
$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
```

Consistency FTW ... thanks @hsbt ! :pray: