### PR TITLE
Remove unused argument

### DIFF
--- a/lib/rake/task_manager.rb
+++ b/lib/rake/task_manager.rb
@@ -35,7 +35,7 @@ module Rake
       task.set_arg_names(arg_names) unless arg_names.empty?
       if Rake::TaskManager.record_task_metadata
         add_location(task)
-        task.add_description(get_description(task))
+        task.add_description(get_description)
       end
       task.enhance(Task.format_deps(deps), &block)
       task | order_only unless order_only.nil?
@@ -316,7 +316,7 @@ module Rake
     end
 
     # Return the current description, clearing it in the process.
-    def get_description(task)
+    def get_description
       desc = @last_description
       @last_description = nil
       desc


### PR DESCRIPTION
I found an unused argument and removed it.

It looks like a leftover from [this commit](https://github.com/ruby/rake/commit/72bdd5d14f34ffdc7a26e4438690cd91b04d2d33#diff-a6c0e245bb30f1b0fc461a5c9b896f91d50498046437742ac114ba2ce21a6c79L293-R292).