### PR TITLE
Fix RDoc links in Rake Information section

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,10 +74,10 @@ Type "rake --help" for all available options.
 
 === Rake Information
 
-* {Rake command-line}[link:doc/command_line_usage.rdoc]
-* {Writing Rakefiles}[link:doc/rakefile.rdoc]
-* The original {Rake announcement}[link:doc/rational.rdoc]
-* Rake {glossary}[link:doc/glossary.rdoc]
+* {Rake command-line}[rdoc-ref:doc/command_line_usage.rdoc]
+* {Writing Rakefiles}[rdoc-ref:doc/rakefile.rdoc]
+* The original {Rake announcement}[rdoc-ref:doc/rational.rdoc]
+* Rake {glossary}[rdoc-ref:doc/glossary.rdoc]
 
 === Presentations and Articles about Rake
 


### PR DESCRIPTION
## Summary

This PR fixes the broken links in the Rake Information section of the documentation. Changed the link format from `link:doc/...` to `rdoc-ref:doc/...` so that RDoc properly resolves these links when generating HTML documentation.

## Problem

When the RDoc documentation is generated, the four links in the Rake Information section do not work properly. This is because the links are using the `link:` format which does not correctly translate to HTML hyperlinks during the documentation generation process.

## Solution

Modified the link format in README.rdoc from `link:doc/...` to `rdoc-ref:doc/...`. This change ensures that RDoc correctly processes these references when generating HTML documentation.

## Affected files

- README.rdoc

## Testing

After making the changes, I regenerated the documentation using `bundle exec rake rdoc` and verified that all four links in the Rake Information section now function correctly.