### PR TITLE
Use latest RDoc release instead of Ruby 3.2's default version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development do
   gem "test-unit"
   gem "coveralls"
   gem "rubocop"
+  gem "rdoc"
 end


### PR DESCRIPTION
By simply using the latest RDoc release, we can immediately improve https://ruby.github.io/rake's user experience:

<img width="80%" alt="Screenshot 2025-05-19 at 21 30 29" src="https://github.com/user-attachments/assets/5878b9f0-a111-42a2-8e55-8c43186a537a" />
