### PR TITLE
Fix TaskArguments#deconstruct_keys with keys = nil

### DIFF
--- a/lib/rake/task_arguments.rb
+++ b/lib/rake/task_arguments.rb
@@ -95,7 +95,7 @@ module Rake
     end
 
     def deconstruct_keys(keys)
-      @hash.slice(*keys)
+      keys ? @hash.slice(*keys) : to_hash
     end
 
     protected

--- a/test/test_rake_task_arguments.rb
+++ b/test/test_rake_task_arguments.rb
@@ -58,6 +58,7 @@ class TestRakeTaskArguments < Rake::TestCase # :nodoc:
     omit "No stable pattern matching until Ruby 3.1 (testing #{RUBY_VERSION})" if RUBY_VERSION < "3.1"
 
     ta = Rake::TaskArguments.new([:a, :b, :c], [1, 2, 3])
+    assert_equal ta.deconstruct_keys(nil), { a: 1, b: 2, c: 3 }
     assert_equal ta.deconstruct_keys([:a, :b]), { a: 1, b: 2 }
   end
 


### PR DESCRIPTION
This fixes a bug in the initial implementation (#515):

`#deconstruct_keys` should handle `keys == nil`, or `**rest` will be broken.

For example, the normal behavior looks like this:
```ruby
  {a: 1, b: 2, c: 3} => {a:, **rest}
  a     # => 1
  rest  # => {b: 2, c: 3}
```

But without handling `keys == nil`, we'll get this:
```ruby
  class Example
    def initialize(hash) = @hash = hash
    def deconstruct_keys(keys) = @hash.slice(*keys)
  end

  Example.new({a: 1, b: 2, c: 3}) => {a:, **rest}
  # !> "#{inspect}: key not found: :a" (NoMatchingPatternKeyError)
```
