### PR TITLE
Remove useless condition check

### DIFF
--- a/lib/rake/thread_pool.rb
+++ b/lib/rake/thread_pool.rb
@@ -108,19 +108,13 @@ module Rake
       false
     end
 
-    def safe_thread_count
-      @threads_mon.synchronize do
-        @threads.count
-      end
-    end
-
     def start_thread # :nodoc:
       @threads_mon.synchronize do
         next unless @threads.count < @max_active_threads
 
         t = Thread.new do
           begin
-            while safe_thread_count <= @max_active_threads
+            loop do
               break unless process_queue_item
             end
           ensure


### PR DESCRIPTION
Since threads count is already guaranteed to be less or equal than max_active_threads in thread_pool.rb:line 113, there is no need to double check.

Not to mention that this will cause a race condition on the JRuby platform, as noted in 5ac9df09d6be3fbb7edb127f31aa0684db620cd3.

Removing the conditional check will also reduce lock acquisitions and improve overall efficiency.

In the original commit 173745949fa299d20a558c0511c02991f056933d, this check was essential. However, after subsequent changes, it seems no one performed a careful review of this logic.