### PR TITLE
Fixed wrong name of environmental variable

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -29,4 +29,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.MATZBOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.MATZBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```