### PR TITLE
Set source_code_uri metadata to this gem's public repo URL

### DIFF
--- a/rake.gemspec
+++ b/rake.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "bug_tracker_uri" => "https://github.com/ruby/rake/issues",
     "changelog_uri" => "https://github.com/ruby/rake/releases",
     "documentation_uri" => "https://ruby.github.io/rake",
-    "source_code_uri" => "#{s.homepage}/releases/v#{s.version}"
+    "source_code_uri" => s.homepage
   }
 
   s.files = [


### PR DESCRIPTION
Currently, each rake gem release's `source_code_uri` points to its "releases" page URL on GitHub, e.g. https://github.com/ruby/rake/releases/v13.3.0 but that's not indeed a source_code_uri.

Instead, let's simply link_to `https://github.com/ruby/rake`. That's what the `bundle gem` template suggests:
https://github.com/rubygems/rubygems/blob/fcb672f/bundler/lib/bundler/cli/gem.rb#L54
and almost all documentations and test data in rubygems/bundler look like. https://github.com/search?q=repo%3Arubygems%2Frubygems%20source_code_uri&type=code
Or, IMO the name "source code URI" implies that it should at least return a URL that can be `git clone`d.

FYI the configuration was introduced via #328 but there wasn't any detailed discussion about the validity of the value.