### PR TITLE
refactor: fix ambiguous regexp / assertion in one of the tests

### DIFF
--- a/test/test_rake_rake_test_loader.rb
+++ b/test/test_rake_rake_test_loader.rb
@@ -54,7 +54,7 @@ class TestRakeRakeTestLoader < Rake::TestCase # :nodoc:
         load @loader
       end
 
-      assert_match /.* -- superkalifragilisticoespialidoso/, exc.message
+      assert_match(/.* -- superkalifragilisticoespialidoso/, exc.message)
     end
     assert_empty out
     assert_empty err


### PR DESCRIPTION
[![released](https://released.blabberate.com/p/ruby/rake/667/badge.svg)](https://released.blabberate.com/p/ruby/rake/667) **refactor: fix ambiguous regexp / assertion in one of the tests**

---

Running `rake test` on the master branch outputs the following Ruby syntax warning:

```
.../test/test_rake_rake_test_loader.rb:57:
warning: ambiguous `/`; wrap regexp in parentheses or add a space after `/` operator
```

Wrapping the `assert_match()` arguments in parentheses fixes the ambiguity, and - what's more - makes the assertion syntax consistent with [similar assertions throughout the `rake` codebase](https://github.com/search?q=repo%3Aruby%2Frake+%2Fassert_match%28.*%2C+.*%29%2F&type=code) #consistency_ftw :tada:

***before:***

```shell
$ ruby -w -c test/test_rake_rake_test_loader.rb
test/test_rake_rake_test_loader.rb:57: warning: ambiguous `/`; wrap regexp in parentheses or add a space after `/` operator
Syntax OK
$ _
```

***after:***

```shell
$ ruby -w -c test/test_rake_rake_test_loader.rb
Syntax OK
$ _
```

