### PR TITLE
Replace Rake's Win32-specific logic with a 100% equivalent, pure-Ruby implementation

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -761,7 +761,7 @@ module Rake
     # The standard directory containing system wide rake files.
     if Win32.windows?
       def standard_system_dir #:nodoc:
-        Win32.win32_system_dir
+        File.join(Dir.home, "Rake")
       end
     else
       def standard_system_dir #:nodoc:

--- a/lib/rake/win32.rb
+++ b/lib/rake/win32.rb
@@ -6,46 +6,12 @@ module Rake
   # will be placed here to collect that knowledge in one spot.
   module Win32 # :nodoc: all
 
-    # Error indicating a problem in locating the home directory on a
-    # Win32 system.
-    class Win32HomeError < RuntimeError
-    end
-
     class << self
       # True if running on a windows system.
       def windows?
         RbConfig::CONFIG["host_os"] =~ %r!(msdos|mswin|djgpp|mingw|[Ww]indows)!
       end
-
-      # The standard directory containing system wide rake files on
-      # Win 32 systems. Try the following environment variables (in
-      # order):
-      #
-      # * HOME
-      # * HOMEDRIVE + HOMEPATH
-      # * APPDATA
-      # * USERPROFILE
-      #
-      # If the above are not defined, the return nil.
-      def win32_system_dir #:nodoc:
-        win32_shared_path = ENV["HOME"]
-        if win32_shared_path.nil? && ENV["HOMEDRIVE"] && ENV["HOMEPATH"]
-          win32_shared_path = ENV["HOMEDRIVE"] + ENV["HOMEPATH"]
-        end
-
-        win32_shared_path ||= ENV["APPDATA"]
-        win32_shared_path ||= ENV["USERPROFILE"]
-        raise Win32HomeError,
-          "Unable to determine home path environment variable." if
-            win32_shared_path.nil? or win32_shared_path.empty?
-        normalize(File.join(win32_shared_path, "Rake"))
-      end
-
-      # Normalize a win32 path so that the slashes are all forward slashes.
-      def normalize(path)
-        path.gsub(/\\/, "/")
-      end
-
     end
+
   end
 end

--- a/test/test_rake_win32.rb
+++ b/test/test_rake_win32.rb
@@ -3,55 +3,6 @@ require File.expand_path("../helper", __FILE__)
 
 class TestRakeWin32 < Rake::TestCase # :nodoc:
 
-  Win32 = Rake::Win32 # :nodoc:
-
-  def test_win32_system_dir_uses_home_if_defined
-    ENV["HOME"] = 'C:\\HP'
-
-    assert_equal "C:/HP/Rake", Win32.win32_system_dir
-  end
-
-  def test_win32_system_dir_uses_homedrive_homepath_when_no_home_defined
-    ENV["HOME"]      = nil
-    ENV["HOMEDRIVE"] = "C:"
-    ENV["HOMEPATH"]  = '\\HP'
-
-    assert_equal "C:/HP/Rake", Win32.win32_system_dir
-  end
-
-  def test_win32_system_dir_uses_appdata_when_no_home_or_home_combo
-    ENV["APPDATA"]   = "C:\\Documents and Settings\\HP\\Application Data"
-    ENV["HOME"]      = nil
-    ENV["HOMEDRIVE"] = nil
-    ENV["HOMEPATH"]  = nil
-
-    assert_equal "C:/Documents and Settings/HP/Application Data/Rake",
-                 Win32.win32_system_dir
-  end
-
-  def test_win32_system_dir_fallback_to_userprofile_otherwise
-    ENV["HOME"]        = nil
-    ENV["HOMEDRIVE"]   = nil
-    ENV["HOMEPATH"]    = nil
-    ENV["APPDATA"]     = nil
-    ENV["USERPROFILE"] = "C:\\Documents and Settings\\HP"
-
-    assert_equal "C:/Documents and Settings/HP/Rake", Win32.win32_system_dir
-  end
-
-  def test_win32_system_dir_nil_of_no_env_vars
-    ENV["APPDATA"]     = nil
-    ENV["HOME"]        = nil
-    ENV["HOMEDRIVE"]   = nil
-    ENV["HOMEPATH"]    = nil
-    ENV["RAKE_SYSTEM"] = nil
-    ENV["USERPROFILE"] = nil
-
-    assert_raises(Rake::Win32::Win32HomeError) do
-      Win32.win32_system_dir
-    end
-  end
-
   def test_win32_backtrace_with_different_case
     ex = nil
     begin


### PR DESCRIPTION
[![released](https://released.blabberate.com/p/ruby/rake/669/badge.svg)](https://released.blabberate.com/p/ruby/rake/669) **Replace Rake's Win32-specific logic with a 100% equivalent, pure-Ruby implementation**

---

tl;dr - replace some Win32-specific Rake logic for Windows home directory detection logic with Ruby's built-in `Dir.home` method

Rake's custom Windows-specific implementation (`Rake::Win32::win32_system_dir`) produces identical results to Ruby's standard library approach (`File.join(Dir.home, "Rake")`) for all possible scenarios it caters for, so this PR removes a whole bunch of superfluous code and corresponding tests.

It is replaced with a much simpler, pure stdlib-based implementation. in a low-risk manner: Ruby's cross-platform `Dir.home` has been available since Ruby 1.9 and is the standard way to get the home directory; this change simply stops reinventing the wheel. :smiley:

1. **Simpler code** — Removes ~85 lines of custom Win32 path handling code, tests, and a custom exception class
2. **More correct** — Dir.home is Ruby's official, well-tested cross-platform solution that handles edge cases properly. The old implementation had a hand-rolled fallback chain (HOME → HOMEDRIVE+HOMEPATH → APPDATA → USERPROFILE) that Ruby already handles correctly internally
3. **Less maintenance burden** — No need to maintain Windows-specific path normalization or environment variable logic that duplicates Ruby stdlib functionality
4. **Consistent behavior** — Aligns Rake's behavior with how other Ruby tools determine the home directory on Windows

Because it's hard to use and test something that isn't there anymore :smile: I've raised an accompanying DRAFT pull request #670 that explicitly tests the equivalency of both versions against the master branch _(for a variety of different scenarios)_  thereby demonstrating that the Rake-specific patch is superfluous and can be safely removed.
