### PR TITLE
[DON'T MERGE] `win32_system_dir` comparison script & GitHub action

### DIFF
--- a/.github/workflows/win32_system_dir.yml
+++ b/.github/workflows/win32_system_dir.yml
@@ -1,0 +1,33 @@
+name: win32
+
+on: [push, pull_request]
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      min_version: 2.3
+      engine: cruby-jruby
+      versions: '["truffleruby"]'
+
+  win32-system-dir:
+    needs: ruby-versions
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        exclude:
+          - ruby: truffleruby
+          - ruby: jruby-head
+          - ruby: jruby
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run "win32_system_dir" comparison
+      run: .\win32_system_dir.bat
+      shell: cmd

--- a/win32_system_dir.bat
+++ b/win32_system_dir.bat
@@ -1,0 +1,154 @@
+@ECHO OFF
+
+ECHO ---------------------------------------------------------------
+ruby -I lib -r rake -e "print '    platform: ' + (Rake::Win32.windows? ? 'Windows' : 'Unix')"
+ruby -e "puts ' / branch: ' + %%x{git symbolic-ref --quiet --short HEAD}.chomp"
+ECHO:
+
+GOTO :main
+
+:echoWindowsEnv
+ECHO [Windows] %%HOME%%=%HOME%
+ECHO [Windows] %%HOMEDRIVE%%=%HOMEDRIVE%
+ECHO [Windows] %%HOMEPATH%%=%HOMEPATH%
+ECHO [Windows] %%APPDATA%%=%APPDATA%
+ECHO [Windows] %%USERPROFILE%%=%USERPROFILE%
+ECHO:
+GOTO :eof
+
+:putsRubyEnv
+ruby -e 'puts "[Ruby] ENV[\"HOME\"] = " + ENV.fetch("HOME", "nil")'
+ruby -e 'puts "[Ruby] ENV[\"HOMEDRIVE\"] = " + ENV.fetch("HOMEDRIVE", "nil")'
+ruby -e 'puts "[Ruby] ENV[\"HOMEPATH\"] = " + ENV.fetch("HOMEPATH", "nil")'
+ruby -e 'puts "[Ruby] ENV[\"APPDATA\"] = " + ENV.fetch("APPDATA", "nil")'
+ruby -e 'puts "[Ruby] ENV[\"USERPROFILE\"] = " + ENV.fetch("USERPROFILE", "nil")'
+ECHO:
+GOTO :eof
+
+:returnRubyDirHome
+for /f "delims=" %%i in ('ruby -e "puts File.join(Dir.home, \"Rake\")"') do set RUBY_DIR=%%i
+GOTO :eof
+
+:returnRakeWin32SystemDir
+for /f "delims=" %%i in ('ruby -I lib -r rake -e "puts Rake::Win32::win32_system_dir"') do set RAKE_DIR=%%i
+GOTO :eof
+
+:compareValues
+CALL :returnRubyDirHome
+CALL :returnRakeWin32SystemDir
+ECHO [Ruby] File.join^(Dir.home, "Rake"^)   =^> %RUBY_DIR%
+ECHO [Rake] Rake::Win32::win32_system_dir =^> %RAKE_DIR%
+if "%RUBY_DIR%"=="%RAKE_DIR%" (
+    ECHO ✅ PASS: Values match
+) else (
+    ECHO ❌ FAIL: Values do not match
+    set /a FAILURE_COUNT+=1
+)
+GOTO :eof
+
+:main
+
+SET FAILURE_COUNT=0
+
+ECHO ---------------------------------------------------------------
+ECHO 1/5 - %%HOME%% set in Windows env
+ECHO ---------------------------------------------------------------
+
+SET HOME=C:\HP
+SET HOMEDRIVE=
+SET HOMEPATH=
+SET APPDATA=
+SET USERPROFILE=
+
+CALL :echoWindowsEnv
+CALL :putsRubyEnv
+
+CALL :compareValues
+
+ECHO:
+
+ECHO ---------------------------------------------------------------
+ECHO 2/5 - %%HOMEDRIVE%% and %%HOMEPATH%% set in Windows env
+ECHO ---------------------------------------------------------------
+
+SET HOME=
+SET HOMEDRIVE=C:
+SET HOMEPATH=\HP
+SET APPDATA=
+SET USERPROFILE=
+
+CALL :echoWindowsEnv
+CALL :putsRubyEnv
+
+CALL :compareValues
+
+ECHO:
+
+ECHO ---------------------------------------------------------------
+ECHO 3/5 - %%APPDATA%% set in Windows env
+ECHO ---------------------------------------------------------------
+
+SET HOME=
+SET HOMEDRIVE=
+SET HOMEPATH=
+SET APPDATA=C:\Documents and Settings\HP\Application Data
+SET USERPROFILE=
+
+CALL :echoWindowsEnv
+CALL :putsRubyEnv
+
+CALL :compareValues
+
+ECHO:
+
+ECHO ---------------------------------------------------------------
+ECHO 4/5 - %%USERPROFILE%% set in Windows env
+ECHO ---------------------------------------------------------------
+
+SET HOME=
+SET HOMEDRIVE=
+SET HOMEPATH=
+SET APPDATA=
+SET USERPROFILE=C:\Documents and Settings\HP
+
+CALL :echoWindowsEnv
+CALL :putsRubyEnv
+
+CALL :compareValues
+
+ECHO:
+
+ECHO ---------------------------------------------------------------
+ECHO 5/5 - nothing set in Windows env
+ECHO ---------------------------------------------------------------
+ECHO       Ruby *always* sets HOME [and USER for that matter]
+ECHO       in *its* environment, even if these are not set in
+ECHO       the Windows environment.
+ECHO:
+ECHO       https://github.com/ruby/ruby/commit/c41cefd492
+ECHO ---------------------------------------------------------------
+
+SET HOME=
+SET HOMEDRIVE=
+SET HOMEPATH=
+SET APPDATA=
+SET USERPROFILE=
+
+CALL :echoWindowsEnv
+CALL :putsRubyEnv
+
+CALL :compareValues
+
+ECHO:
+
+ECHO ----------------------------------
+ECHO:
+
+if %FAILURE_COUNT% GTR 0 (
+    ECHO ❌ OVERALL RESULT: %FAILURE_COUNT% test^(s^) failed
+    exit /b 1
+) else (
+    ECHO ✅ OVERALL RESULT: All tests passed
+    exit /b 0
+)
+


### PR DESCRIPTION
Before removing it in #669 this draft PR _(submitted as evidence only for the other PR)_ is intended  to validate the equivalency of two approaches for determining Rake's "standard system directory" on Windows platforms, using "real life" scenarios that cannot be correctly reproduced in the unit tests.

The ultimate goal is to prove that Rake's custom Windows-specific implementation (`Rake::Win32::win32_system_dir`) produces identical results to Ruby's standard library approach (`File.join(Dir.home, "Rake")`), thereby demonstrating that the Rake-specific patch is superfluous and can be safely removed.

The Windows batch script calculates and compares the value for `win32_system_dir` using both approaches for the 5 scenarios also covered by the unit tests:

1. `%%HOME%%` set in Windows env
2. `%%HOMEDRIVE%%` and `%%HOMEPATH%%` set in Windows env
3. `%%APPDATA%%` set in Windows env
4. `%%USERPROFILE%%` set in Windows env
5. nothing set in Windows env

... and runs it - as the `win32` workflow in GitHub actions - for all Ruby versions supported on the Windows platform.

<details>
  <summary>‼️ CLICK to see batch script output for "head" version of Ruby on Windows</summary>

```shell
---------------------------------------------------------------
    platform: Windows / branch: 

---------------------------------------------------------------
1/5 - %HOME% set in Windows env
---------------------------------------------------------------
[Windows] %HOME%=C:\HP
[Windows] %HOMEDRIVE%=
[Windows] %HOMEPATH%=
[Windows] %APPDATA%=
[Windows] %USERPROFILE%=

[Ruby] ENV["HOME"] = C:\HP
[Ruby] ENV["HOMEDRIVE"] = nil
[Ruby] ENV["HOMEPATH"] = nil
[Ruby] ENV["APPDATA"] = nil
[Ruby] ENV["USERPROFILE"] = nil

[Ruby] File.join(Dir.home, "Rake")   => C:/HP/Rake
[Rake] Rake::Win32::win32_system_dir => C:/HP/Rake
✅ PASS: Values match

---------------------------------------------------------------
2/5 - %HOMEDRIVE% and %HOMEPATH% set in Windows env
---------------------------------------------------------------
[Windows] %HOME%=
[Windows] %HOMEDRIVE%=C:
[Windows] %HOMEPATH%=\HP
[Windows] %APPDATA%=
[Windows] %USERPROFILE%=

[Ruby] ENV["HOME"] = C:/HP
[Ruby] ENV["HOMEDRIVE"] = C:
[Ruby] ENV["HOMEPATH"] = \HP
[Ruby] ENV["APPDATA"] = nil
[Ruby] ENV["USERPROFILE"] = nil

[Ruby] File.join(Dir.home, "Rake")   => C:/HP/Rake
[Rake] Rake::Win32::win32_system_dir => C:/HP/Rake
✅ PASS: Values match

---------------------------------------------------------------
3/5 - %APPDATA% set in Windows env
---------------------------------------------------------------
[Windows] %HOME%=
[Windows] %HOMEDRIVE%=
[Windows] %HOMEPATH%=
[Windows] %APPDATA%=C:\Documents and Settings\HP\Application Data
[Windows] %USERPROFILE%=

[Ruby] ENV["HOME"] = C:/Users/runneradmin
[Ruby] ENV["HOMEDRIVE"] = nil
[Ruby] ENV["HOMEPATH"] = nil
[Ruby] ENV["APPDATA"] = C:\Documents and Settings\HP\Application Data
[Ruby] ENV["USERPROFILE"] = nil

[Ruby] File.join(Dir.home, "Rake")   => C:/Users/runneradmin/Rake
[Rake] Rake::Win32::win32_system_dir => C:/Users/runneradmin/Rake
✅ PASS: Values match

---------------------------------------------------------------
4/5 - %USERPROFILE% set in Windows env
---------------------------------------------------------------
[Windows] %HOME%=
[Windows] %HOMEDRIVE%=
[Windows] %HOMEPATH%=
[Windows] %APPDATA%=
[Windows] %USERPROFILE%=C:\Documents and Settings\HP

[Ruby] ENV["HOME"] = C:/Documents and Settings/HP
[Ruby] ENV["HOMEDRIVE"] = nil
[Ruby] ENV["HOMEPATH"] = nil
[Ruby] ENV["APPDATA"] = nil
[Ruby] ENV["USERPROFILE"] = C:\Documents and Settings\HP

[Ruby] File.join(Dir.home, "Rake")   => C:/Documents and Settings/HP/Rake
[Rake] Rake::Win32::win32_system_dir => C:/Documents and Settings/HP/Rake
✅ PASS: Values match

---------------------------------------------------------------
5/5 - nothing set in Windows env
---------------------------------------------------------------
      Ruby *always* sets HOME [and USER for that matter]
      in *its* environment, even if these are not set in
      the Windows environment.

      https://github.com/ruby/ruby/commit/c41cefd492
---------------------------------------------------------------
[Windows] %HOME%=
[Windows] %HOMEDRIVE%=
[Windows] %HOMEPATH%=
[Windows] %APPDATA%=
[Windows] %USERPROFILE%=

[Ruby] ENV["HOME"] = C:/Users/runneradmin
[Ruby] ENV["HOMEDRIVE"] = nil
[Ruby] ENV["HOMEPATH"] = nil
[Ruby] ENV["APPDATA"] = nil
[Ruby] ENV["USERPROFILE"] = nil

[Ruby] File.join(Dir.home, "Rake")   => C:/Users/runneradmin/Rake
[Rake] Rake::Win32::win32_system_dir => C:/Users/runneradmin/Rake
✅ PASS: Values match

----------------------------------

✅ OVERALL RESULT: All tests passed
```

</details>

This comprehensive testing approach ensures that the removal of `Rake::Win32::win32_system_dir` in #669 is both safe and well-validated across the entire ecosystem of supported Ruby versions and Windows environment configurations.

> [!Note]
> Once #669 has been reviewed, approved and merged, this PR can be closed.