### PR TITLE
Dedupe and simplify `standard_system_dir`

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -754,12 +754,10 @@ module Rake
     end
 
     # The standard directory containing system wide rake files.
-    if Win32.windows?
-      def standard_system_dir #:nodoc:
+    def standard_system_dir #:nodoc:
+      if windows?
         File.join(Dir.home, "Rake")
-      end
-    else
-      def standard_system_dir #:nodoc:
+      else
         File.join(Dir.home, ".rake")
       end
     end

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -365,6 +365,44 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     flunk "failed to find system rakefile"
   end
 
+  def test_load_from_calculated_system_rakefile_on_windows
+    rakefile_default
+    def @app.windows?
+      true
+    end
+
+    @app.instance_eval do
+      handle_options []
+      options.silent = true
+      options.load_system = true
+      options.rakelib = []
+      load_rakefile
+    end
+
+    assert_equal File.join(Dir.home, "Rake"), @app.system_dir
+  rescue SystemExit
+    flunk "failed to find system rakefile"
+  end
+
+  def test_load_from_calculated_system_rakefile_on_unix
+    rakefile_default
+    def @app.windows?
+      false
+    end
+
+    @app.instance_eval do
+      handle_options []
+      options.silent = true
+      options.load_system = true
+      options.rakelib = []
+      load_rakefile
+    end
+
+    assert_equal File.join(Dir.home, ".rake"), @app.system_dir
+  rescue SystemExit
+    flunk "failed to find system rakefile"
+  end
+
   def test_terminal_columns
     old_rake_columns = ENV["RAKE_COLUMNS"]
 


### PR DESCRIPTION
[![released](https://released.blabberate.com/p/ruby/rake/713/badge.svg)](https://released.blabberate.com/p/ruby/rake/713) **Dedupe and simplify `standard_system_dir`**

---

Hot on the heels of #669, this small refactor dedupes the multiple method definitions by inlining the `Win32.windows?` check, which means we don't end up with two different method implementations for the same thing, which is a tad confusing for e.g. `ctags`:

<img width="1580" height="1030" alt="ctags" src="https://github.com/user-attachments/assets/53c3679f-576c-4897-9831-231f2d382116" />

It also replaces the duplicated `Win32.windows?` check with the existing `Rake::Application.windows?` utility function, already used elsewhere in the class.

This in turn allowed me to add two explicit tests, one for the Windows behaviour, another one for the Unix behaviour; it does this by stubbing the `Rake::Application.windows?` utility function, which is indeed a tad strange, but both tests are modelled after the existing `test_load_from_calculated_system_rakefile` _(which is arguably even stranger, as it needs to stub a private function in order to do its thing)_ :smiley: