### PR TITLE
Add support for test-unit loader

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -181,8 +181,8 @@ module Rake
       case @loader
       when :direct
         "-e \"ARGV.each{|f| require f}\""
-      when :testrb
-        "-S testrb"
+      when :"test-unit"
+        "-S test-unit"
       when :rake
         "#{__dir__}/rake_test_loader.rb"
       end

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -145,6 +145,14 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
     assert_equal globbed, test_task.file_list.to_a
   end
 
+  test "run code test-unit" do
+    test_task = Rake::TestTask.new do |t|
+      t.loader = :"test-unit"
+    end
+
+    assert_equal("-S test-unit", test_task.run_code)
+  end
+
   def test_run_code_rake
     spec = Gem::Specification.new "rake", 0
     spec.loaded_from = File.join Gem::Specification.dirs.last, "rake-0.gemspec"


### PR DESCRIPTION
Since test-unit 3.6.8 supports the `test-unit` command. And the `testrb` command is no longer available.