### PR TITLE
Skip option-like arguments in the :direct test loader

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -180,7 +180,7 @@ module Rake
     def run_code # :nodoc:
       case @loader
       when :direct
-        "-e \"ARGV.each{|f| require f}\""
+        "-e \"ARGV.each{|f| require f unless f.start_with?('-')}\""
       when :"test-unit"
         "-S test-unit"
       when :rake

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -141,8 +141,32 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
       # t.pettern is "test/test*.rb"
     end
 
-    assert_equal '-e "ARGV.each{|f| require f}"', test_task.run_code
+    assert_equal %q{-e "ARGV.each{|f| require f unless f.start_with?('-')}"}, test_task.run_code
     assert_equal globbed, test_task.file_list.to_a
+  end
+
+  def test_run_code_direct_skips_option_arguments
+    test_task = Rake::TestTask.new do |t|
+      t.loader = :direct
+      t.verbose = true
+    end
+
+    code = test_task.run_code[/\A-e "(.*)"\z/, 1]
+    refute_nil code
+
+    required = []
+    receiver = Object.new
+    receiver.define_singleton_method(:require) { |file| required << file }
+
+    saved_argv = ARGV.dup
+    begin
+      ARGV.replace(["test/foo_test.rb", "-v"])
+      receiver.instance_eval(code)
+    ensure
+      ARGV.replace(saved_argv)
+    end
+
+    assert_equal ["test/foo_test.rb"], required
   end
 
   test "run code test-unit" do


### PR DESCRIPTION
The :direct loader required every ARGV entry, so a verbose run that appended -v tried to require "-v" and aborted with a LoadError. Skip arguments starting with "-", matching rake_test_loader.rb.

Fixes https://github.com/ruby/rake/issues/724