### PR TITLE
Don't leak the global verbose flag into the test runner's ARGV

### DIFF
--- a/lib/rake/testtask.rb
+++ b/lib/rake/testtask.rb
@@ -110,9 +110,12 @@ module Rake
       task @name => Array(deps) do
         effective_verbose = @verbose || FileUtilsExt.verbose_flag == true
         FileUtilsExt.verbose(effective_verbose) do
+          # The global verbose flag (e.g. set by --trace or -n) controls
+          # whether rake echoes the command, but it must not inject "-v"
+          # into the test runner's ARGV. Only the task's own @verbose does.
           args =
             "#{ruby_opts_string} #{run_code} " +
-            "#{file_list_string} #{option_list(verbose: effective_verbose)}"
+            "#{file_list_string} #{option_list(verbose: @verbose)}"
           ruby args do |ok, status|
             if !ok && status.respond_to?(:signaled?) && status.signaled?
               raise SignalException.new(status.termsig)

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -20,18 +20,6 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
     super
   end
 
-  # Run the test task's action with the +ruby+ invocation stubbed out and
-  # return the command string that would have been executed.
-  def captured_test_command(test_task)
-    command = nil
-    test_task.define_singleton_method(:ruby) do |*args, **_opts, &_block|
-      command = args.first
-      nil
-    end
-    Rake::Task[test_task.name].execute
-    command
-  end
-
   def test_initialize
     tt = Rake::TestTask.new do |t| end
     refute_nil tt
@@ -275,5 +263,19 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
     assert_equal ["b"], t.prerequisites
     assert_equal ["c"], t.order_only_prerequisites
     assert_equal [b, c], t.prerequisite_tasks
+  end
+
+  private
+
+  # Run the test task's action with the +ruby+ invocation stubbed out and
+  # return the command string that would have been executed.
+  def captured_test_command(test_task)
+    command = nil
+    test_task.define_singleton_method(:ruby) do |*args, **_opts, &_block|
+      command = args.first
+      nil
+    end
+    Rake::Task[test_task.name].execute
+    command
   end
 end

--- a/test/test_rake_test_task.rb
+++ b/test/test_rake_test_task.rb
@@ -20,6 +20,18 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
     super
   end
 
+  # Run the test task's action with the +ruby+ invocation stubbed out and
+  # return the command string that would have been executed.
+  def captured_test_command(test_task)
+    command = nil
+    test_task.define_singleton_method(:ruby) do |*args, **_opts, &_block|
+      command = args.first
+      nil
+    end
+    Rake::Task[test_task.name].execute
+    command
+  end
+
   def test_initialize
     tt = Rake::TestTask.new do |t| end
     refute_nil tt
@@ -240,6 +252,21 @@ class TestRakeTestTask < Rake::TestCase # :nodoc:
   def test_option_list_verbose_keyword_overrides
     tt = Rake::TestTask.new { |t| t.verbose = false }
     assert_equal "-v", tt.option_list(verbose: true)
+  end
+
+  def test_run_omits_v_for_global_verbose_only
+    # --trace and -n set the global verbose flag via Rake.verbose(true), but
+    # that must not leak "-v" into the test runner's ARGV. (issue #732)
+    Rake::FileUtilsExt.verbose_flag = true
+    tt = Rake::TestTask.new { |t| t.verbose = false }
+    refute_includes captured_test_command(tt).split, "-v"
+  ensure
+    Rake::FileUtilsExt.verbose_flag = false
+  end
+
+  def test_run_injects_v_for_task_verbose
+    tt = Rake::TestTask.new { |t| t.verbose = true }
+    assert_includes captured_test_command(tt).split, "-v"
   end
 
   def test_task_order_only_prerequisites_key


### PR DESCRIPTION
`--trace` and `-n` set the global verbose flag, which since 13.4.2 caused `TestTask` to append `-v` to TESTOPTS. The `:rake` loader passes that `-v` on to the test process ARGV, breaking apps that inspect ARGV at load time (e.g. Sinatra) under `rake test --trace`.

The task block now keeps echoing the command for the global flag but bases the `-v` injection only on the task's own `@verbose`, so `t.verbose = true` and `TESTOPTS=-v` are unchanged.

Fixes #732