### PR TITLE
Add pattern filter to display prerequisites

### DIFF
--- a/lib/rake/application.rb
+++ b/lib/rake/application.rb
@@ -404,7 +404,11 @@ module Rake
 
     # Display the tasks and prerequisites
     def display_prerequisites # :nodoc:
-      tasks.each do |t|
+      displayable_tasks = tasks.select { |t|
+        t.name =~ options.show_prereq_pattern
+      }
+
+      displayable_tasks.each do |t|
         puts "#{name} #{t.name}"
         t.prerequisites.each { |pre| puts "    #{pre}" }
       end
@@ -531,9 +535,11 @@ module Rake
             "-N", "Do not search parent directories for the Rakefile.",
             lambda { |value| options.nosearch = true }
           ],
-          ["--prereqs", "-P",
-            "Display the tasks and dependencies, then exit.",
-            lambda { |value| options.show_prereqs = true }
+          ["--prereqs", "-P [PATTERN]",
+           "Display the tasks (matching optional PATTERN) and dependencies, then exit.",
+           lambda { |value|
+             select_prereqs_to_show(options, value)
+           }
           ],
           ["--quiet", "-q",
             "Do not log messages to standard output.",
@@ -641,6 +647,12 @@ module Rake
           ],
         ])
     end
+
+    def select_prereqs_to_show(options, value) # :nodoc:
+      options.show_prereqs = true
+      options.show_prereq_pattern = Regexp.new(value || "")
+    end
+    private :select_prereqs_to_show
 
     def select_tasks_to_show(options, show_tasks, value) # :nodoc:
       options.show_tasks = show_tasks

--- a/lib/rake/options.rb
+++ b/lib/rake/options.rb
@@ -17,6 +17,7 @@ module Rake
     attr_accessor :nosearch
     attr_accessor :rakelib
     attr_accessor :show_all_tasks
+    attr_accessor :show_prereq_pattern
     attr_accessor :show_prereqs
     attr_accessor :show_task_pattern
     attr_accessor :show_tasks

--- a/test/test_rake_application.rb
+++ b/test/test_rake_application.rb
@@ -528,6 +528,28 @@ class TestRakeApplication < Rake::TestCase # :nodoc:
     assert_match(/rake default\n( *(a|b)\n){2}/m, out)
   end
 
+  def test_display_prereqs_with_pattern
+    @app.last_description = "COMMENT"
+    t = @app.define_task(Rake::Task, "ci")
+    t.enhance([:test, :rubocop])
+    @app.define_task(Rake::Task, "rubocop")
+    @app.define_task(Rake::Task, "test")
+    @app.define_task(Rake::Task, "test:system")
+    @app.in_namespace("ci") do
+      @app.in_namespace("artifacts") do
+        @app.define_task(Rake::Task, "export")
+      end
+    end
+    out, = capture_output { @app.run %w[-f -s -P ci --rakelib=""] }
+    assert @app.options.show_prereqs
+    assert_equal <<~OUTPUT, out
+      rake ci
+          test
+          rubocop
+      rake ci:artifacts:export
+    OUTPUT
+  end
+
   def test_bad_run
     @app.intern(Rake::Task, "default").enhance { fail }
     _, err = capture_output {


### PR DESCRIPTION
Invoking `rake -P` can result in a very long list. You might only be interested in the prerequisites of (say) `db:reset`. To get to this piece of information faster we add the same pattern filtering known and loved in `rake -T`.